### PR TITLE
Expose node checklists in the configuration panel

### DIFF
--- a/components/node-config-panel.tsx
+++ b/components/node-config-panel.tsx
@@ -10,6 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch"
 import type { WorkflowNode } from "@/lib/types"
 import CodeEditor from "./code-editor"
+import { NodeTaskList } from "./nodes/node-task-list"
 
 interface NodeConfigPanelProps {
   node: WorkflowNode
@@ -247,6 +248,24 @@ export default function NodeConfigPanel({ node, updateNodeData, onClose }: NodeC
         <div className="border-t border-gray-200 my-4"></div>
 
         {renderInputFields()}
+
+        <div className="border-t border-gray-200 my-4"></div>
+
+        <p className="text-xs text-gray-500">
+          Manage this node&apos;s checklist, set due dates, and mark work complete without leaving the
+          configuration view.
+        </p>
+
+        <NodeTaskList
+          nodeId={node.id}
+          tasks={node.data.tasks ?? []}
+          availableTasks={node.data.availableTasks}
+          onAddTask={node.data.createTask}
+          onAttachTask={node.data.assignTask}
+          onDueDateChange={node.data.updateTaskDueDate}
+          onMarkDone={node.data.markTaskDone}
+          className="mt-2"
+        />
       </div>
     </div>
   )

--- a/components/nodes/node-task-list.tsx
+++ b/components/nodes/node-task-list.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { useState, type ChangeEvent } from "react"
+
+import type { Task } from "@/lib/types"
+import { cn } from "@/lib/utils"
+
+interface NodeTaskListProps {
+  nodeId: string
+  tasks: Task[]
+  availableTasks?: Task[]
+  className?: string
+  title?: string
+  onAddTask?: (nodeId: string, text: string) => void
+  onAttachTask?: (taskId: number, nodeId: string) => void
+  onDueDateChange?: (taskId: number, due: string) => void
+  onMarkDone?: (taskId: number) => void
+}
+
+const placeholderOption = ""
+
+export function NodeTaskList({
+  nodeId,
+  tasks,
+  availableTasks,
+  className,
+  title = "Task Checklist",
+  onAddTask,
+  onAttachTask,
+  onDueDateChange,
+  onMarkDone,
+}: NodeTaskListProps) {
+  const [newTaskText, setNewTaskText] = useState("")
+  const [selectedTaskId, setSelectedTaskId] = useState<string>(placeholderOption)
+
+  const handleCreateTask = () => {
+    const trimmed = newTaskText.trim()
+    if (!trimmed || !onAddTask) return
+
+    onAddTask(nodeId, trimmed)
+    setNewTaskText("")
+  }
+
+  const handleAssignExisting = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value
+    setSelectedTaskId(value)
+
+    if (!value || !onAttachTask) return
+
+    const parsedId = Number(value)
+    if (Number.isNaN(parsedId)) return
+
+    onAttachTask(parsedId, nodeId)
+    setSelectedTaskId(placeholderOption)
+  }
+
+  return (
+    <div
+      className={cn(
+        "space-y-2 rounded-md border border-dashed border-gray-200 bg-gray-50 p-2",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">{title}</span>
+        {onAttachTask && availableTasks && availableTasks.length > 0 ? (
+          <select
+            value={selectedTaskId}
+            onChange={handleAssignExisting}
+            className="rounded border px-2 py-1 text-[10px] text-gray-700"
+          >
+            <option value={placeholderOption}>Add from checklist</option>
+            {availableTasks.map((task) => (
+              <option key={task.id} value={task.id}>
+                {task.text}
+              </option>
+            ))}
+          </select>
+        ) : null}
+      </div>
+
+      {tasks.length > 0 ? (
+        <div className="space-y-2">
+          {tasks.map((task) => (
+            <div key={task.id} className="space-y-1 rounded border bg-white p-2">
+              <div className="text-xs font-medium text-gray-800">{task.text}</div>
+              <input
+                type="datetime-local"
+                value={task.due}
+                onChange={(event) => onDueDateChange?.(task.id, event.target.value)}
+                className="w-full rounded border px-2 py-1 text-[10px]"
+                disabled={!onDueDateChange}
+              />
+              <button
+                type="button"
+                onClick={() => onMarkDone?.(task.id)}
+                disabled={task.completed || !onMarkDone}
+                className={`w-full rounded px-2 py-1 text-[10px] font-medium ${
+                  task.completed
+                    ? "bg-green-100 text-green-700"
+                    : "bg-blue-500 text-white hover:bg-blue-600"
+                } ${!onMarkDone ? "opacity-50" : ""}`}
+              >
+                {task.completed ? "Done" : "Mark as done"}
+              </button>
+              {task.completed && (
+                <div className="text-[10px] text-gray-500">
+                  Completed by {task.completedBy}
+                  {task.completedAt ? ` at ${task.completedAt}` : ""}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded border border-dashed border-gray-300 bg-white p-2 text-[10px] text-gray-500">
+          No tasks yet. Use the field below to create one.
+        </div>
+      )}
+
+      {onAddTask ? (
+        <div className="flex items-center gap-2">
+          <input
+            value={newTaskText}
+            onChange={(event) => setNewTaskText(event.target.value)}
+            placeholder="Add action item"
+            className="flex-1 rounded border px-2 py-1 text-[10px]"
+          />
+          <button
+            type="button"
+            onClick={handleCreateTask}
+            className="rounded bg-blue-500 px-2 py-1 text-[10px] font-medium text-white hover:bg-blue-600"
+          >
+            Add
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/workflow-builder.tsx
+++ b/components/workflow-builder.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useCallback, useRef } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 import ReactFlow, {
   ReactFlowProvider,
   Background,
@@ -32,7 +32,7 @@ import { ConditionalNode } from "./nodes/conditional-node"
 import { CodeNode } from "./nodes/code-node"
 import { generateNodeId, createNode } from "@/lib/workflow-utils"
 import { cn } from "@/lib/utils"
-import type { WorkflowNode } from "@/lib/types"
+import type { Task, WorkflowNode } from "@/lib/types"
 
 const nodeTypes: NodeTypes = {
   input: InputNode,
@@ -46,11 +46,48 @@ const edgeTypes: EdgeTypes = {
   custom: CustomEdge,
 }
 
-type WorkflowBuilderProps = {
-  className?: string
+const areTaskListsEqual = (a?: Task[], b: Task[] = []): boolean => {
+  if (!a && b.length === 0) {
+    return true
+  }
+
+  if (!a || a.length !== b.length) {
+    return false
+  }
+
+  return a.every((task, index) => {
+    const other = b[index]
+    return (
+      task.id === other.id &&
+      task.text === other.text &&
+      task.due === other.due &&
+      task.completed === other.completed &&
+      task.completedBy === other.completedBy &&
+      task.completedAt === other.completedAt &&
+      task.nodeId === other.nodeId
+    )
+  })
 }
 
-export default function WorkflowBuilder({ className }: WorkflowBuilderProps) {
+type WorkflowBuilderProps = {
+  className?: string
+  tasks?: Task[]
+  availableTasks?: Task[]
+  onAssignTask?: (taskId: number, nodeId: string | null) => void
+  onCreateTask?: (nodeId: string, text: string) => void
+  onUpdateTaskDueDate?: (taskId: number, due: string) => void
+  onMarkTaskDone?: (taskId: number) => void
+}
+
+export default function WorkflowBuilder({
+  className,
+  tasks,
+  availableTasks,
+  onAssignTask,
+  onCreateTask,
+  onUpdateTaskDueDate,
+  onMarkTaskDone,
+}: WorkflowBuilderProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null)
   const [nodes, setNodes, onNodesChange] = useNodesState([])
   const [edges, setEdges, onEdgesChange] = useEdgesState([])
@@ -124,6 +161,80 @@ export default function WorkflowBuilder({ className }: WorkflowBuilderProps) {
     },
     [setNodes],
   )
+
+  useEffect(() => {
+    setNodes((nds) => {
+      if (!nds.length) {
+        return nds
+      }
+
+      let hasChanges = false
+
+      const nextNodes = nds.map((node) => {
+        const nodeTasks = (tasks ?? []).filter((task) => task.nodeId === node.id)
+        const tasksChanged = !areTaskListsEqual(node.data.tasks, nodeTasks)
+        const availableChanged = !areTaskListsEqual(node.data.availableTasks, availableTasks ?? [])
+        const assignChanged = node.data.assignTask !== onAssignTask
+        const createChanged = node.data.createTask !== onCreateTask
+        const dueChanged = node.data.updateTaskDueDate !== onUpdateTaskDueDate
+        const markChanged = node.data.markTaskDone !== onMarkTaskDone
+
+        if (
+          !tasksChanged &&
+          !availableChanged &&
+          !assignChanged &&
+          !createChanged &&
+          !dueChanged &&
+          !markChanged
+        ) {
+          return node
+        }
+
+        hasChanges = true
+
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            tasks: nodeTasks,
+            availableTasks: availableTasks ?? [],
+            assignTask: onAssignTask,
+            createTask: onCreateTask,
+            updateTaskDueDate: onUpdateTaskDueDate,
+            markTaskDone: onMarkTaskDone,
+          },
+        }
+      })
+
+      return hasChanges ? nextNodes : nds
+    })
+  }, [
+    nodes,
+    tasks,
+    availableTasks,
+    onAssignTask,
+    onCreateTask,
+    onUpdateTaskDueDate,
+    onMarkTaskDone,
+    setNodes,
+  ])
+
+  useEffect(() => {
+    if (!selectedNode) {
+      return
+    }
+
+    const updated = nodes.find((node) => node.id === selectedNode.id)
+
+    if (!updated) {
+      setSelectedNode(null)
+      return
+    }
+
+    if (updated !== selectedNode) {
+      setSelectedNode(updated)
+    }
+  }, [nodes, selectedNode])
 
   const saveWorkflow = () => {
     if (nodes.length === 0) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,15 @@
 import type { Node } from "reactflow"
 
+export interface Task {
+  id: number
+  text: string
+  due: string
+  completed: boolean
+  completedBy: string
+  completedAt: string | null
+  nodeId: string | null
+}
+
 export interface NodeData {
   label: string
   description?: string
@@ -25,6 +35,14 @@ export interface NodeData {
   // Code node properties
   codeLanguage?: "javascript" | "typescript"
   code?: string
+
+  // Task management
+  tasks?: Task[]
+  availableTasks?: Task[]
+  assignTask?: (taskId: number, nodeId: string | null) => void
+  createTask?: (nodeId: string, text: string) => void
+  updateTaskDueDate?: (taskId: number, due: string) => void
+  markTaskDone?: (taskId: number) => void
 }
 
 export type WorkflowNode = Node<NodeData>

--- a/lib/workflow-utils.ts
+++ b/lib/workflow-utils.ts
@@ -24,6 +24,7 @@ export const createNode = ({
     data: {
       label: getDefaultLabel(type),
       description: getDefaultDescription(type),
+      tasks: [],
     },
   }
 


### PR DESCRIPTION
## Summary
- expose each node's checklist management from the configuration panel while restoring the workflow nodes to their original appearance
- update the process view and workflow builder to attach checklist items to nodes and surface them in the calendar

## Testing
- pnpm lint *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68cb439be7e083249f65f456ce307c96