### PR TITLE
Remove node task UIs from nodes and move checklist

### DIFF
--- a/components/node-config-panel.tsx
+++ b/components/node-config-panel.tsx
@@ -211,6 +211,11 @@ export default function NodeConfigPanel({ node, updateNodeData, onClose }: NodeC
     }
   }
 
+  const hasTaskManagement =
+    (node.data.tasks?.length ?? 0) > 0 ||
+    (node.data.availableTasks?.length ?? 0) > 0 ||
+    Boolean(node.data.createTask)
+
   return (
     <div className="h-full flex flex-col">
       <div className="flex justify-between items-center mb-4">
@@ -245,27 +250,31 @@ export default function NodeConfigPanel({ node, updateNodeData, onClose }: NodeC
           <Label htmlFor="required">Required Node</Label>
         </div>
 
+        {hasTaskManagement ? (
+          <div>
+            <p className="text-xs text-gray-500">
+              Manage this node&apos;s checklist, set due dates, and mark work complete without leaving the
+              configuration view.
+            </p>
+
+            <NodeTaskList
+              nodeId={node.id}
+              tasks={node.data.tasks ?? []}
+              availableTasks={node.data.availableTasks}
+              onAddTask={node.data.createTask}
+              onAttachTask={node.data.assignTask}
+              onDueDateChange={node.data.updateTaskDueDate}
+              onMarkDone={node.data.markTaskDone}
+              className="mt-2"
+            />
+          </div>
+        ) : null}
+
         <div className="border-t border-gray-200 my-4"></div>
 
         {renderInputFields()}
 
         <div className="border-t border-gray-200 my-4"></div>
-
-        <p className="text-xs text-gray-500">
-          Manage this node&apos;s checklist, set due dates, and mark work complete without leaving the
-          configuration view.
-        </p>
-
-        <NodeTaskList
-          nodeId={node.id}
-          tasks={node.data.tasks ?? []}
-          availableTasks={node.data.availableTasks}
-          onAddTask={node.data.createTask}
-          onAttachTask={node.data.assignTask}
-          onDueDateChange={node.data.updateTaskDueDate}
-          onMarkDone={node.data.markTaskDone}
-          className="mt-2"
-        />
       </div>
     </div>
   )

--- a/components/nodes/code-node.tsx
+++ b/components/nodes/code-node.tsx
@@ -4,14 +4,7 @@ import { memo } from "react"
 import { Handle, Position, type NodeProps } from "reactflow"
 import { Code } from "lucide-react"
 import type { NodeData } from "@/lib/types"
-import { NodeTaskList } from "./node-task-list"
-
 export const CodeNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) => {
-  const showTaskList =
-    (data.tasks?.length ?? 0) > 0 ||
-    (data.availableTasks?.length ?? 0) > 0 ||
-    Boolean(data.createTask)
-
   return (
     <div className="px-4 py-2 shadow-md rounded-md bg-white border-2 border-gray-500 min-w-[150px]">
       <div className="flex items-center">
@@ -31,21 +24,6 @@ export const CodeNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) 
           Language: {data.codeLanguage}
         </div>
       )}
-
-      {showTaskList ? (
-        <NodeTaskList
-          nodeId={id}
-          tasks={data.tasks ?? []}
-          availableTasks={data.availableTasks}
-          onAddTask={data.createTask}
-          onAttachTask={data.assignTask}
-          onDueDateChange={data.updateTaskDueDate}
-          onMarkDone={data.markTaskDone}
-          title="Tasks"
-          variant="node"
-          className="mt-3"
-        />
-      ) : null}
 
       <Handle
         type="target"

--- a/components/nodes/conditional-node.tsx
+++ b/components/nodes/conditional-node.tsx
@@ -4,14 +4,7 @@ import { memo } from "react"
 import { Handle, Position, type NodeProps } from "reactflow"
 import { GitBranch } from "lucide-react"
 import type { NodeData } from "@/lib/types"
-import { NodeTaskList } from "./node-task-list"
-
 export const ConditionalNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) => {
-  const showTaskList =
-    (data.tasks?.length ?? 0) > 0 ||
-    (data.availableTasks?.length ?? 0) > 0 ||
-    Boolean(data.createTask)
-
   return (
     <div className="px-4 py-2 shadow-md rounded-md bg-white border-2 border-amber-500 min-w-[150px]">
       <div className="flex items-center">
@@ -36,21 +29,6 @@ export const ConditionalNode = memo(({ id, data, isConnectable }: NodeProps<Node
         <div className="text-green-600">{data.trueLabel || "Yes"}</div>
         <div className="text-red-600">{data.falseLabel || "No"}</div>
       </div>
-
-      {showTaskList ? (
-        <NodeTaskList
-          nodeId={id}
-          tasks={data.tasks ?? []}
-          availableTasks={data.availableTasks}
-          onAddTask={data.createTask}
-          onAttachTask={data.assignTask}
-          onDueDateChange={data.updateTaskDueDate}
-          onMarkDone={data.markTaskDone}
-          title="Tasks"
-          variant="node"
-          className="mt-3"
-        />
-      ) : null}
 
       <Handle
         type="target"

--- a/components/nodes/input-node.tsx
+++ b/components/nodes/input-node.tsx
@@ -4,14 +4,7 @@ import { memo } from "react"
 import { Handle, Position, type NodeProps } from "reactflow"
 import { Database } from "lucide-react"
 import type { NodeData } from "@/lib/types"
-import { NodeTaskList } from "./node-task-list"
-
 export const InputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) => {
-  const showTaskList =
-    (data.tasks?.length ?? 0) > 0 ||
-    (data.availableTasks?.length ?? 0) > 0 ||
-    Boolean(data.createTask)
-
   return (
     <div className="px-4 py-2 shadow-md rounded-md bg-white border-2 border-blue-500 min-w-[150px]">
       <div className="flex items-center">
@@ -31,21 +24,6 @@ export const InputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>)
           Source: {data.dataSource}
         </div>
       )}
-
-      {showTaskList ? (
-        <NodeTaskList
-          nodeId={id}
-          tasks={data.tasks ?? []}
-          availableTasks={data.availableTasks}
-          onAddTask={data.createTask}
-          onAttachTask={data.assignTask}
-          onDueDateChange={data.updateTaskDueDate}
-          onMarkDone={data.markTaskDone}
-          title="Tasks"
-          variant="node"
-          className="mt-3"
-        />
-      ) : null}
 
       <Handle
         type="source"

--- a/components/nodes/output-node.tsx
+++ b/components/nodes/output-node.tsx
@@ -4,14 +4,7 @@ import { memo } from "react"
 import { Handle, Position, type NodeProps } from "reactflow"
 import { FileOutput } from "lucide-react"
 import type { NodeData } from "@/lib/types"
-import { NodeTaskList } from "./node-task-list"
-
 export const OutputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) => {
-  const showTaskList =
-    (data.tasks?.length ?? 0) > 0 ||
-    (data.availableTasks?.length ?? 0) > 0 ||
-    Boolean(data.createTask)
-
   return (
     <div className="px-4 py-2 shadow-md rounded-md bg-white border-2 border-green-500 min-w-[150px]">
       <div className="flex items-center">
@@ -31,21 +24,6 @@ export const OutputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>
           Output: {data.outputType} ({data.outputFormat || "json"})
         </div>
       )}
-
-      {showTaskList ? (
-        <NodeTaskList
-          nodeId={id}
-          tasks={data.tasks ?? []}
-          availableTasks={data.availableTasks}
-          onAddTask={data.createTask}
-          onAttachTask={data.assignTask}
-          onDueDateChange={data.updateTaskDueDate}
-          onMarkDone={data.markTaskDone}
-          title="Tasks"
-          variant="node"
-          className="mt-3"
-        />
-      ) : null}
 
       <Handle
         type="target"

--- a/components/nodes/process-node.tsx
+++ b/components/nodes/process-node.tsx
@@ -4,14 +4,7 @@ import { memo } from "react"
 import { Handle, Position, type NodeProps } from "reactflow"
 import { Settings } from "lucide-react"
 import type { NodeData } from "@/lib/types"
-import { NodeTaskList } from "./node-task-list"
-
 export const ProcessNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) => {
-  const showTaskList =
-    (data.tasks?.length ?? 0) > 0 ||
-    (data.availableTasks?.length ?? 0) > 0 ||
-    Boolean(data.createTask)
-
   return (
     <div className="px-4 py-2 shadow-md rounded-md bg-white border-2 border-purple-500 min-w-[150px]">
       <div className="flex items-center">
@@ -31,21 +24,6 @@ export const ProcessNode = memo(({ id, data, isConnectable }: NodeProps<NodeData
           Process: {data.processType}
         </div>
       )}
-
-      {showTaskList ? (
-        <NodeTaskList
-          nodeId={id}
-          tasks={data.tasks ?? []}
-          availableTasks={data.availableTasks}
-          onAddTask={data.createTask}
-          onAttachTask={data.assignTask}
-          onDueDateChange={data.updateTaskDueDate}
-          onMarkDone={data.markTaskDone}
-          title="Tasks"
-          variant="node"
-          className="mt-3"
-        />
-      ) : null}
 
       <Handle
         type="target"


### PR DESCRIPTION
## Summary
- remove the task checklist UI from the input, output, process, conditional, and code nodes so tasks are no longer shown inside the node cards
- surface the task management block (create task, assignments, etc.) directly below the "Required Node" control in the configuration panel

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc17cea8a88324a2a82bef4250a0fa