### PR TITLE
Preserve process view state across tab changes

### DIFF
--- a/components/ops-catalog.tsx
+++ b/components/ops-catalog.tsx
@@ -559,25 +559,41 @@ export default function OpsCatalog() {
             )}
           </div>
 
-          <div
-            className={cn(
-              "flex-1 p-4",
-              viewMode === "process" ? "overflow-hidden" : "overflow-y-auto",
-            )}
-          >
+          <div className="flex-1 p-4">
             {!selectedSOP ? (
               <div className="text-sm text-gray-500">
                 Select an SOP from the left to preview.
               </div>
-            ) : viewMode === "editor" ? (
-              <Editor
-                content={selectedSOP.content}
-                onChange={(value) => updateSOP(selectedSOP.id, value)}
-              />
-            ) : viewMode === "process" ? (
-              <ProcessView tasks={tasks} setTasks={setTasks} />
             ) : (
-              <CalendarView tasks={tasks} />
+              <div className="h-full">
+                <div
+                  className={cn(
+                    "flex h-full flex-col overflow-y-auto",
+                    viewMode !== "editor" && "hidden",
+                  )}
+                >
+                  <Editor
+                    content={selectedSOP.content}
+                    onChange={(value) => updateSOP(selectedSOP.id, value)}
+                  />
+                </div>
+                <div
+                  className={cn(
+                    "flex h-full flex-col overflow-hidden",
+                    viewMode !== "process" && "hidden",
+                  )}
+                >
+                  <ProcessView tasks={tasks} setTasks={setTasks} />
+                </div>
+                <div
+                  className={cn(
+                    "flex h-full flex-col overflow-y-auto",
+                    viewMode !== "calendar" && "hidden",
+                  )}
+                >
+                  <CalendarView tasks={tasks} />
+                </div>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- keep the editor, process, and calendar panels mounted and toggle visibility with CSS so workflow state persists while switching views

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2a4453b08324978840ed0af9f294