### PR TITLE
Refine SOP actions in categories list

### DIFF
--- a/components/ops-catalog.tsx
+++ b/components/ops-catalog.tsx
@@ -16,6 +16,7 @@ import {
   FileText,
   ListChecks,
   Maximize2,
+  MoreHorizontal,
   Minimize2,
   Pencil,
   Plus,
@@ -27,6 +28,12 @@ import {
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import {
   Select,
@@ -1565,7 +1572,16 @@ Describe the goal of the procedure.
                                       />
                                     ) : (
                                       <>
-                                        <div className="truncate font-medium">{sop.title}</div>
+                                        <button
+                                          type="button"
+                                          onClick={() => {
+                                            setSelectedSOP(sop)
+                                            setViewMode("editor")
+                                          }}
+                                          className="w-full truncate text-left font-medium text-gray-900 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40"
+                                        >
+                                          {sop.title}
+                                        </button>
                                         <div className="truncate text-xs text-gray-500">
                                           {sop.owner} • Updated {sop.lastUpdated}
                                         </div>
@@ -1615,31 +1631,36 @@ Describe the goal of the procedure.
                                       </button>
                                     </>
                                   ) : (
-                                    <>
-                                      <button
-                                        onClick={() => {
-                                          setSelectedSOP(sop)
-                                          setViewMode("editor")
-                                        }}
-                                        className="rounded-lg border px-2 py-1 text-xs hover:bg-gray-50"
-                                      >
-                                        Open SOP
-                                      </button>
-                                      <button
-                                        onClick={() => startEditSop(category.id, sop)}
-                                        className="rounded-lg border p-2 hover:bg-gray-50"
-                                        aria-label={`Edit ${sop.title}`}
-                                      >
-                                        <Pencil className="h-4 w-4" />
-                                      </button>
-                                      <button
-                                        onClick={() => handleDeleteSop(category.id, sop.id)}
-                                        className="rounded-lg border p-2 text-red-600 hover:bg-red-50"
-                                        aria-label={`Delete ${sop.title}`}
-                                      >
-                                        <Trash2 className="h-4 w-4" />
-                                      </button>
-                                    </>
+                                    <DropdownMenu>
+                                      <DropdownMenuTrigger asChild>
+                                        <button
+                                          type="button"
+                                          className="rounded-lg border p-2 hover:bg-gray-50"
+                                          aria-label={`SOP actions for ${sop.title}`}
+                                        >
+                                          <MoreHorizontal className="h-4 w-4" />
+                                        </button>
+                                      </DropdownMenuTrigger>
+                                      <DropdownMenuContent align="end" className="w-44">
+                                        <DropdownMenuItem
+                                          onSelect={(event) => {
+                                            event.preventDefault()
+                                            startEditSop(category.id, sop)
+                                          }}
+                                        >
+                                          <Pencil className="mr-2 h-4 w-4" /> Edit
+                                        </DropdownMenuItem>
+                                        <DropdownMenuItem
+                                          onSelect={(event) => {
+                                            event.preventDefault()
+                                            handleDeleteSop(category.id, sop.id)
+                                          }}
+                                          className="text-red-600 focus:text-red-600"
+                                        >
+                                          <Trash2 className="mr-2 h-4 w-4" /> Delete
+                                        </DropdownMenuItem>
+                                      </DropdownMenuContent>
+                                    </DropdownMenu>
                                   )}
                                 </div>
                               </div>


### PR DESCRIPTION
## Summary
- move SOP-level edit and delete controls into a three-dot dropdown menu
- remove the standalone Open button by making SOP titles open the editor when clicked

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8ecfb4ec83248d35f976ac6c276e