### PR TITLE
Replace profile avatar with placeholder asset

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,218 @@
 import OpsCatalog from "@/components/ops-catalog"
+import { Avatar } from "@/components/avatar"
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownDivider,
+  DropdownItem,
+  DropdownLabel,
+  DropdownMenu,
+} from "@/components/dropdown"
+import { Navbar, NavbarItem, NavbarSection, NavbarSpacer } from "@/components/navbar"
+import {
+  Sidebar,
+  SidebarBody,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarHeading,
+  SidebarItem,
+  SidebarLabel,
+  SidebarSection,
+  SidebarSpacer,
+} from "@/components/sidebar"
+import { SidebarLayout } from "@/components/sidebar-layout"
+import {
+  ChevronDown,
+  ChevronUp,
+  Cog,
+  HelpCircle,
+  Home,
+  Inbox,
+  Layers,
+  Lightbulb,
+  LogOut,
+  Megaphone,
+  Plus,
+  Search,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  Ticket,
+  User,
+} from "lucide-react"
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col">
-      <div className="flex-1">
-        <OpsCatalog />
-      </div>
-    </main>
+    <SidebarLayout
+      navbar={
+        <Navbar>
+          <NavbarSpacer />
+          <NavbarSection>
+            <NavbarItem href="/search" aria-label="Search">
+              <Search aria-hidden="true" data-slot="icon" />
+            </NavbarItem>
+            <NavbarItem href="/inbox" aria-label="Inbox">
+              <Inbox aria-hidden="true" data-slot="icon" />
+            </NavbarItem>
+            <Dropdown>
+              <DropdownButton as={NavbarItem}>
+                <Avatar src="/placeholder-user.jpg" square />
+              </DropdownButton>
+              <DropdownMenu className="min-w-64" anchor="bottom end">
+                <DropdownItem href="/my-profile">
+                  <User aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>My profile</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/settings">
+                  <Cog aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Settings</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/privacy-policy">
+                  <ShieldCheck aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Privacy policy</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/share-feedback">
+                  <Lightbulb aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Share feedback</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/logout">
+                  <LogOut aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Sign out</DropdownLabel>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </NavbarSection>
+        </Navbar>
+      }
+      sidebar={
+        <Sidebar>
+          <SidebarHeader>
+            <Dropdown>
+              <DropdownButton as={SidebarItem} className="lg:mb-2.5">
+                <Avatar src="/placeholder-logo.svg" />
+                <SidebarLabel>Tailwind Labs</SidebarLabel>
+                <ChevronDown aria-hidden="true" data-slot="icon" />
+              </DropdownButton>
+              <DropdownMenu className="min-w-80 lg:min-w-64" anchor="bottom start">
+                <DropdownItem href="/teams/1/settings">
+                  <Cog aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Settings</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/teams/1">
+                  <Avatar slot="icon" src="/placeholder-logo.svg" />
+                  <DropdownLabel>Tailwind Labs</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/teams/2">
+                  <Avatar slot="icon" initials="WC" className="bg-purple-500 text-white" />
+                  <DropdownLabel>Workcation</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/teams/create">
+                  <Plus aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>New team&hellip;</DropdownLabel>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+            <SidebarSection className="max-lg:hidden">
+              <SidebarItem href="/search">
+                <Search aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Search</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/inbox">
+                <Inbox aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Inbox</SidebarLabel>
+              </SidebarItem>
+            </SidebarSection>
+          </SidebarHeader>
+          <SidebarBody>
+            <SidebarSection>
+              <SidebarItem href="/">
+                <Home aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Home</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/events">
+                <Layers aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Events</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/orders">
+                <Ticket aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Orders</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/settings">
+                <Settings2 aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Settings</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/broadcasts">
+                <Megaphone aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Broadcasts</SidebarLabel>
+              </SidebarItem>
+            </SidebarSection>
+            <SidebarSection className="max-lg:hidden">
+              <SidebarHeading>Upcoming Events</SidebarHeading>
+              <SidebarItem href="/events/1">Bear Hug: Live in Concert</SidebarItem>
+              <SidebarItem href="/events/2">Viking People</SidebarItem>
+              <SidebarItem href="/events/3">Six Fingers — DJ Set</SidebarItem>
+              <SidebarItem href="/events/4">We All Look The Same</SidebarItem>
+            </SidebarSection>
+            <SidebarSpacer />
+            <SidebarSection>
+              <SidebarItem href="/support">
+                <HelpCircle aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Support</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/changelog">
+                <Sparkles aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Changelog</SidebarLabel>
+              </SidebarItem>
+            </SidebarSection>
+          </SidebarBody>
+          <SidebarFooter className="max-lg:hidden">
+            <Dropdown>
+              <DropdownButton as={SidebarItem}>
+                <span className="flex min-w-0 items-center gap-3">
+                  <Avatar src="/placeholder-user.jpg" className="size-10" square alt="" />
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm/5 font-medium text-zinc-950 dark:text-white">Erica</span>
+                    <span className="block truncate text-xs/5 font-normal text-zinc-500 dark:text-zinc-400">
+                      erica@example.com
+                    </span>
+                  </span>
+                </span>
+                <ChevronUp aria-hidden="true" data-slot="icon" />
+              </DropdownButton>
+              <DropdownMenu className="min-w-64" anchor="top start">
+                <DropdownItem href="/my-profile">
+                  <User aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>My profile</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/settings">
+                  <Cog aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Settings</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/privacy-policy">
+                  <ShieldCheck aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Privacy policy</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/share-feedback">
+                  <Lightbulb aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Share feedback</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/logout">
+                  <LogOut aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Sign out</DropdownLabel>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </SidebarFooter>
+        </Sidebar>
+      }
+    >
+      <OpsCatalog />
+    </SidebarLayout>
   )
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -45,19 +45,19 @@ export const NavbarItem = forwardRef(function NavbarItem(
     // Base
     'relative flex min-w-0 items-center gap-3 rounded-lg p-2 text-left text-base/6 font-medium text-zinc-950 sm:text-sm/5',
     // Leading icon/icon-only
-    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 sm:*:data-[slot=icon]:size-5',
+    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 *:data-[slot=icon]:text-zinc-500 sm:*:data-[slot=icon]:size-5',
     // Trailing icon (down chevron or similar)
     '*:not-nth-2:last:data-[slot=icon]:ml-auto *:not-nth-2:last:data-[slot=icon]:size-5 sm:*:not-nth-2:last:data-[slot=icon]:size-4',
     // Avatar
     '*:data-[slot=avatar]:-m-0.5 *:data-[slot=avatar]:size-7 *:data-[slot=avatar]:[--avatar-radius:var(--radius-md)] sm:*:data-[slot=avatar]:size-6',
     // Hover
-    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950',
+    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950 data-hover:*:data-[slot=icon]:text-zinc-950',
     // Active
-    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950',
+    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950 data-active:*:data-[slot=icon]:text-zinc-950',
     // Dark mode
-    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400',
-    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white',
-    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white'
+    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400 dark:*:data-[slot=icon]:text-zinc-400',
+    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white dark:data-hover:*:data-[slot=icon]:text-white',
+    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white dark:data-active:*:data-[slot=icon]:text-white'
   )
 
   return (

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -87,22 +87,22 @@ export const SidebarItem = forwardRef(function SidebarItem(
     // Base
     'flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left text-base/6 font-medium text-zinc-950 sm:py-2 sm:text-sm/5',
     // Leading icon/icon-only
-    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 sm:*:data-[slot=icon]:size-5',
+    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 *:data-[slot=icon]:text-zinc-500 sm:*:data-[slot=icon]:size-5',
     // Trailing icon (down chevron or similar)
     '*:last:data-[slot=icon]:ml-auto *:last:data-[slot=icon]:size-5 sm:*:last:data-[slot=icon]:size-4',
     // Avatar
     '*:data-[slot=avatar]:-m-0.5 *:data-[slot=avatar]:size-7 sm:*:data-[slot=avatar]:size-6',
     // Hover
-    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950',
+    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950 data-hover:*:data-[slot=icon]:text-zinc-950',
     // Active
-    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950',
+    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950 data-active:*:data-[slot=icon]:text-zinc-950',
     // Current
-    'data-current:*:data-[slot=icon]:fill-zinc-950',
+    'data-current:*:data-[slot=icon]:fill-zinc-950 data-current:*:data-[slot=icon]:text-zinc-950',
     // Dark mode
-    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400',
-    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white',
-    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white',
-    'dark:data-current:*:data-[slot=icon]:fill-white'
+    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400 dark:*:data-[slot=icon]:text-zinc-400',
+    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white dark:data-hover:*:data-[slot=icon]:text-white',
+    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white dark:data-active:*:data-[slot=icon]:text-white',
+    'dark:data-current:*:data-[slot=icon]:fill-white dark:data-current:*:data-[slot=icon]:text-white'
   )
 
   return (


### PR DESCRIPTION
## Summary
- point the navbar and footer avatars at the existing `placeholder-user.jpg` image
- remove the newly added `public/profile-photo.jpg` asset to avoid binary files in the PR

## Testing
- npm run lint *(fails: ESLint must be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc93e3e8c0832484687c99473dce21