### PR TITLE
Add local shims for headless UI dependencies

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,220 @@
+export const dynamic = "force-dynamic"
+
 import OpsCatalog from "@/components/ops-catalog"
+import { Avatar } from "@/components/avatar"
+import {
+  Dropdown,
+  DropdownButton,
+  DropdownDivider,
+  DropdownItem,
+  DropdownLabel,
+  DropdownMenu,
+} from "@/components/dropdown"
+import { Navbar, NavbarItem, NavbarSection, NavbarSpacer } from "@/components/navbar"
+import {
+  Sidebar,
+  SidebarBody,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarHeading,
+  SidebarItem,
+  SidebarLabel,
+  SidebarSection,
+  SidebarSpacer,
+} from "@/components/sidebar"
+import { SidebarLayout } from "@/components/sidebar-layout"
+import {
+  ChevronDown,
+  ChevronUp,
+  Cog,
+  HelpCircle,
+  Home,
+  Inbox,
+  Layers,
+  Lightbulb,
+  LogOut,
+  Megaphone,
+  Plus,
+  Search,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  Ticket,
+  User,
+} from "lucide-react"
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col">
-      <div className="flex-1">
-        <OpsCatalog />
-      </div>
-    </main>
+    <SidebarLayout
+      navbar={
+        <Navbar>
+          <NavbarSpacer />
+          <NavbarSection>
+            <NavbarItem href="/search" aria-label="Search">
+              <Search aria-hidden="true" data-slot="icon" />
+            </NavbarItem>
+            <NavbarItem href="/inbox" aria-label="Inbox">
+              <Inbox aria-hidden="true" data-slot="icon" />
+            </NavbarItem>
+            <Dropdown>
+              <DropdownButton as={NavbarItem}>
+                <Avatar src="/placeholder-user.jpg" square />
+              </DropdownButton>
+              <DropdownMenu className="min-w-64" anchor="bottom end">
+                <DropdownItem href="/my-profile">
+                  <User aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>My profile</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/settings">
+                  <Cog aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Settings</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/privacy-policy">
+                  <ShieldCheck aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Privacy policy</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/share-feedback">
+                  <Lightbulb aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Share feedback</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/logout">
+                  <LogOut aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Sign out</DropdownLabel>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </NavbarSection>
+        </Navbar>
+      }
+      sidebar={
+        <Sidebar>
+          <SidebarHeader>
+            <Dropdown>
+              <DropdownButton as={SidebarItem} className="lg:mb-2.5">
+                <Avatar src="/placeholder-logo.svg" />
+                <SidebarLabel>Tailwind Labs</SidebarLabel>
+                <ChevronDown aria-hidden="true" data-slot="icon" />
+              </DropdownButton>
+              <DropdownMenu className="min-w-80 lg:min-w-64" anchor="bottom start">
+                <DropdownItem href="/teams/1/settings">
+                  <Cog aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Settings</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/teams/1">
+                  <Avatar slot="icon" src="/placeholder-logo.svg" />
+                  <DropdownLabel>Tailwind Labs</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/teams/2">
+                  <Avatar slot="icon" initials="WC" className="bg-purple-500 text-white" />
+                  <DropdownLabel>Workcation</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/teams/create">
+                  <Plus aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>New team&hellip;</DropdownLabel>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+            <SidebarSection className="max-lg:hidden">
+              <SidebarItem href="/search">
+                <Search aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Search</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/inbox">
+                <Inbox aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Inbox</SidebarLabel>
+              </SidebarItem>
+            </SidebarSection>
+          </SidebarHeader>
+          <SidebarBody>
+            <SidebarSection>
+              <SidebarItem href="/">
+                <Home aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Home</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/events">
+                <Layers aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Events</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/orders">
+                <Ticket aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Orders</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/settings">
+                <Settings2 aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Settings</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/broadcasts">
+                <Megaphone aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Broadcasts</SidebarLabel>
+              </SidebarItem>
+            </SidebarSection>
+            <SidebarSection className="max-lg:hidden">
+              <SidebarHeading>Upcoming Events</SidebarHeading>
+              <SidebarItem href="/events/1">Bear Hug: Live in Concert</SidebarItem>
+              <SidebarItem href="/events/2">Viking People</SidebarItem>
+              <SidebarItem href="/events/3">Six Fingers — DJ Set</SidebarItem>
+              <SidebarItem href="/events/4">We All Look The Same</SidebarItem>
+            </SidebarSection>
+            <SidebarSpacer />
+            <SidebarSection>
+              <SidebarItem href="/support">
+                <HelpCircle aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Support</SidebarLabel>
+              </SidebarItem>
+              <SidebarItem href="/changelog">
+                <Sparkles aria-hidden="true" data-slot="icon" />
+                <SidebarLabel>Changelog</SidebarLabel>
+              </SidebarItem>
+            </SidebarSection>
+          </SidebarBody>
+          <SidebarFooter className="max-lg:hidden">
+            <Dropdown>
+              <DropdownButton as={SidebarItem}>
+                <span className="flex min-w-0 items-center gap-3">
+                  <Avatar src="/placeholder-user.jpg" className="size-10" square alt="" />
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm/5 font-medium text-zinc-950 dark:text-white">Erica</span>
+                    <span className="block truncate text-xs/5 font-normal text-zinc-500 dark:text-zinc-400">
+                      erica@example.com
+                    </span>
+                  </span>
+                </span>
+                <ChevronUp aria-hidden="true" data-slot="icon" />
+              </DropdownButton>
+              <DropdownMenu className="min-w-64" anchor="top start">
+                <DropdownItem href="/my-profile">
+                  <User aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>My profile</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/settings">
+                  <Cog aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Settings</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/privacy-policy">
+                  <ShieldCheck aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Privacy policy</DropdownLabel>
+                </DropdownItem>
+                <DropdownItem href="/share-feedback">
+                  <Lightbulb aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Share feedback</DropdownLabel>
+                </DropdownItem>
+                <DropdownDivider />
+                <DropdownItem href="/logout">
+                  <LogOut aria-hidden="true" data-slot="icon" />
+                  <DropdownLabel>Sign out</DropdownLabel>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </SidebarFooter>
+        </Sidebar>
+      }
+    >
+      <OpsCatalog />
+    </SidebarLayout>
   )
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -45,19 +45,19 @@ export const NavbarItem = forwardRef(function NavbarItem(
     // Base
     'relative flex min-w-0 items-center gap-3 rounded-lg p-2 text-left text-base/6 font-medium text-zinc-950 sm:text-sm/5',
     // Leading icon/icon-only
-    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 sm:*:data-[slot=icon]:size-5',
+    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 *:data-[slot=icon]:text-zinc-500 sm:*:data-[slot=icon]:size-5',
     // Trailing icon (down chevron or similar)
     '*:not-nth-2:last:data-[slot=icon]:ml-auto *:not-nth-2:last:data-[slot=icon]:size-5 sm:*:not-nth-2:last:data-[slot=icon]:size-4',
     // Avatar
     '*:data-[slot=avatar]:-m-0.5 *:data-[slot=avatar]:size-7 *:data-[slot=avatar]:[--avatar-radius:var(--radius-md)] sm:*:data-[slot=avatar]:size-6',
     // Hover
-    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950',
+    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950 data-hover:*:data-[slot=icon]:text-zinc-950',
     // Active
-    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950',
+    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950 data-active:*:data-[slot=icon]:text-zinc-950',
     // Dark mode
-    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400',
-    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white',
-    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white'
+    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400 dark:*:data-[slot=icon]:text-zinc-400',
+    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white dark:data-hover:*:data-[slot=icon]:text-white',
+    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white dark:data-active:*:data-[slot=icon]:text-white'
   )
 
   return (

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -87,22 +87,22 @@ export const SidebarItem = forwardRef(function SidebarItem(
     // Base
     'flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left text-base/6 font-medium text-zinc-950 sm:py-2 sm:text-sm/5',
     // Leading icon/icon-only
-    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 sm:*:data-[slot=icon]:size-5',
+    '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 *:data-[slot=icon]:text-zinc-500 sm:*:data-[slot=icon]:size-5',
     // Trailing icon (down chevron or similar)
     '*:last:data-[slot=icon]:ml-auto *:last:data-[slot=icon]:size-5 sm:*:last:data-[slot=icon]:size-4',
     // Avatar
     '*:data-[slot=avatar]:-m-0.5 *:data-[slot=avatar]:size-7 sm:*:data-[slot=avatar]:size-6',
     // Hover
-    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950',
+    'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950 data-hover:*:data-[slot=icon]:text-zinc-950',
     // Active
-    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950',
+    'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950 data-active:*:data-[slot=icon]:text-zinc-950',
     // Current
-    'data-current:*:data-[slot=icon]:fill-zinc-950',
+    'data-current:*:data-[slot=icon]:fill-zinc-950 data-current:*:data-[slot=icon]:text-zinc-950',
     // Dark mode
-    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400',
-    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white',
-    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white',
-    'dark:data-current:*:data-[slot=icon]:fill-white'
+    'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400 dark:*:data-[slot=icon]:text-zinc-400',
+    'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white dark:data-hover:*:data-[slot=icon]:text-white',
+    'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white dark:data-active:*:data-[slot=icon]:text-white',
+    'dark:data-current:*:data-[slot=icon]:fill-white dark:data-current:*:data-[slot=icon]:text-white'
   )
 
   return (

--- a/lib/headlessui.tsx
+++ b/lib/headlessui.tsx
@@ -1,0 +1,504 @@
+'use client'
+
+import React, {
+  Fragment,
+  type ElementType,
+  type MutableRefObject,
+  type PropsWithChildren,
+  type ReactElement,
+  type Ref,
+  forwardRef,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
+// Helpers
+function mergeRefs<T>(...refs: Array<Ref<T> | undefined>) {
+  return (node: T) => {
+    for (let ref of refs) {
+      if (!ref) continue
+      if (typeof ref === 'function') {
+        ref(node)
+      } else {
+        ;(ref as MutableRefObject<T | null>).current = node
+      }
+    }
+  }
+}
+
+function composeEventHandlers<EventType extends { defaultPrevented: boolean }>(
+  ourHandler: ((event: EventType) => void) | undefined,
+  theirHandler: ((event: EventType) => void) | undefined,
+) {
+  return (event: EventType) => {
+    theirHandler?.(event)
+    if (!event.defaultPrevented) {
+      ourHandler?.(event)
+    }
+  }
+}
+
+// Menu implementation
+interface MenuContextValue {
+  open: boolean
+  setOpen(open: boolean): void
+  buttonRef: MutableRefObject<HTMLElement | null>
+  menuRef: MutableRefObject<HTMLElement | null>
+}
+
+const MenuContext = React.createContext<MenuContextValue | null>(null)
+
+function useMenuContext(component: string) {
+  let context = useContext(MenuContext)
+  if (!context) {
+    throw new Error(`<${component}> must be used within a <Menu>.`)
+  }
+  return context
+}
+
+export type MenuProps = PropsWithChildren<{
+  as?: ElementType
+}>
+
+export function Menu({ as: Component = Fragment, children, ...props }: MenuProps) {
+  let [open, setOpen] = useState(false)
+  let buttonRef = useRef<HTMLElement | null>(null)
+  let menuRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      let target = event.target as Node
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(target)
+      ) {
+        setOpen(false)
+      }
+    }
+
+    function onFocusIn(event: FocusEvent) {
+      let target = event.target as Node
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(target)
+      ) {
+        setOpen(false)
+      }
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+      }
+    }
+
+    window.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('focusin', onFocusIn)
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('focusin', onFocusIn)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  let context = useMemo<MenuContextValue>(
+    () => ({ open, setOpen, buttonRef, menuRef }),
+    [open],
+  )
+
+  return (
+    <MenuContext.Provider value={context}>
+      <Component {...props}>{children}</Component>
+    </MenuContext.Provider>
+  )
+}
+
+export type MenuButtonProps<T extends ElementType = 'button'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+
+export const MenuButton = forwardRef(function MenuButton<T extends ElementType = 'button'>(
+  { as, onClick, ...props }: MenuButtonProps<T>,
+  ref: Ref<Element>,
+) {
+  let { open, setOpen, buttonRef } = useMenuContext('MenuButton')
+  let Component = (as ?? 'button') as ElementType
+
+  let handleClick = composeEventHandlers<React.MouseEvent<Element>>(
+    (event) => {
+      event.preventDefault()
+      setOpen(!open)
+    },
+    onClick as ((event: React.MouseEvent<Element>) => void) | undefined,
+  )
+
+  return (
+    <Component
+      {...(props as Record<string, unknown>)}
+      ref={mergeRefs(ref as Ref<Element>, buttonRef as Ref<Element>)}
+      onClick={handleClick}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      data-open={open ? '' : undefined}
+    />
+  )
+}) as <T extends ElementType = 'button'>(
+  props: MenuButtonProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+export type MenuItemsProps = React.HTMLAttributes<HTMLDivElement> & {
+  anchor?: string
+  transition?: boolean
+}
+
+export const MenuItems = forwardRef<HTMLDivElement, MenuItemsProps>(function MenuItems(
+  { anchor, onKeyDown, style, hidden, ...props },
+  ref,
+) {
+  let { open, setOpen, menuRef, buttonRef } = useMenuContext('MenuItems')
+
+  let handleKeyDown = composeEventHandlers<React.KeyboardEvent<HTMLDivElement>>(
+    (event) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+      }
+    },
+    onKeyDown,
+  )
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      {...props}
+      role="menu"
+      ref={mergeRefs(ref, menuRef)}
+      data-open=""
+      data-anchor={anchor}
+      onKeyDown={handleKeyDown}
+      style={style}
+      tabIndex={-1}
+    />
+  )
+})
+
+export type MenuItemProps<T extends ElementType = 'button'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+
+export const MenuItem = forwardRef(function MenuItem<T extends ElementType = 'button'>(
+  { as, onClick, ...props }: MenuItemProps<T>,
+  ref: Ref<Element>,
+) {
+  let { setOpen } = useMenuContext('MenuItem')
+  let Component = (as ?? 'button') as ElementType
+
+  let handleClick = composeEventHandlers<React.MouseEvent<Element>>(
+    () => {
+      setOpen(false)
+    },
+    onClick as ((event: React.MouseEvent<Element>) => void) | undefined,
+  )
+
+  return (
+    <Component
+      {...(props as Record<string, unknown>)}
+      ref={ref}
+      role="menuitem"
+      tabIndex={-1}
+      onClick={handleClick}
+    />
+  )
+}) as <T extends ElementType = 'button'>(
+  props: MenuItemProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+export type MenuSectionProps = React.HTMLAttributes<HTMLDivElement>
+
+export function MenuSection(props: MenuSectionProps) {
+  return <div {...props} role="group" />
+}
+
+export type MenuHeadingProps = React.HTMLAttributes<HTMLHeadingElement>
+
+export function MenuHeading({ as: _as, ...props }: MenuHeadingProps & { as?: ElementType }) {
+  let Component = (_as ?? 'h3') as ElementType
+  return <Component {...(props as Record<string, unknown>)} />
+}
+
+export type MenuSeparatorProps = React.HTMLAttributes<HTMLHRElement>
+
+export function MenuSeparator(props: MenuSeparatorProps) {
+  return <hr {...props} role="separator" />
+}
+
+export type DescriptionProps<T extends ElementType = 'p'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+
+export const Description = forwardRef(function Description<T extends ElementType = 'p'>(
+  { as, ...props }: DescriptionProps<T>,
+  ref: Ref<Element>,
+) {
+  let Component = (as ?? 'p') as ElementType
+  return <Component {...(props as Record<string, unknown>)} ref={ref} />
+}) as <T extends ElementType = 'p'>(
+  props: DescriptionProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+// Dialog implementation
+interface DialogContextValue {
+  onClose(): void
+}
+
+const DialogContext = React.createContext<DialogContextValue | null>(null)
+
+export type DialogProps = PropsWithChildren<{
+  open: boolean
+  onClose(open: boolean): void
+  className?: string
+}>
+
+export function Dialog({ open, onClose, className, children }: DialogProps) {
+  useEffect(() => {
+    if (!open) return
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        onClose(false)
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [open, onClose])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <DialogContext.Provider value={{ onClose: () => onClose(false) }}>
+      <div className={className}>{children}</div>
+    </DialogContext.Provider>
+  )
+}
+
+function useDialogContext() {
+  return useContext(DialogContext)
+}
+
+export type DialogBackdropProps = React.HTMLAttributes<HTMLDivElement> & {
+  transition?: boolean
+}
+
+export const DialogBackdrop = forwardRef<HTMLDivElement, DialogBackdropProps>(function DialogBackdrop(
+  { onClick, ...props },
+  ref,
+) {
+  let context = useDialogContext()
+
+  let handleClick = composeEventHandlers<React.MouseEvent<HTMLDivElement>>(
+    () => {
+      context?.onClose()
+    },
+    onClick,
+  )
+
+  return <div {...props} ref={ref} onClick={handleClick} />
+})
+
+export type DialogPanelProps = React.HTMLAttributes<HTMLDivElement> & {
+  transition?: boolean
+}
+
+export const DialogPanel = forwardRef<HTMLDivElement, DialogPanelProps>(function DialogPanel(
+  { onClick, ...props },
+  ref,
+) {
+  let handleClick = composeEventHandlers<React.MouseEvent<HTMLDivElement>>(
+    (event) => {
+      event.stopPropagation()
+    },
+    onClick,
+  )
+
+  return <div {...props} ref={ref} onClick={handleClick} />
+})
+
+export type ButtonProps<T extends ElementType = 'button'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+
+export const Button = forwardRef(function Button<T extends ElementType = 'button'>(
+  { as, type, ...props }: ButtonProps<T>,
+  ref: Ref<Element>,
+) {
+  let Component = (as ?? 'button') as ElementType
+  let resolvedType = type ?? (Component === 'button' ? 'button' : undefined)
+  return <Component {...(props as Record<string, unknown>)} ref={ref} type={resolvedType} />
+}) as <T extends ElementType = 'button'>(
+  props: ButtonProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+export type CloseButtonProps<T extends ElementType = 'button'> = ButtonProps<T>
+
+export const CloseButton = forwardRef(function CloseButton<T extends ElementType = 'button'>(
+  { as, onClick, ...props }: CloseButtonProps<T>,
+  ref: Ref<Element>,
+) {
+  let context = useDialogContext()
+  let Component = (as ?? 'button') as ElementType
+
+  let handleClick = composeEventHandlers<React.MouseEvent<Element>>(
+    () => {
+      context?.onClose()
+    },
+    onClick as ((event: React.MouseEvent<Element>) => void) | undefined,
+  )
+
+  return <Component {...(props as Record<string, unknown>)} ref={ref} onClick={handleClick} />
+}) as <T extends ElementType = 'button'>(
+  props: CloseButtonProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+export type DataInteractiveProps = PropsWithChildren<{
+  as?: ElementType
+}>
+
+export function DataInteractive({ as: Component = Fragment, children, ...props }: DataInteractiveProps) {
+  return <Component {...(props as Record<string, unknown>)}>{children}</Component>
+}
+
+export type FieldsetProps = React.ComponentPropsWithoutRef<'fieldset'>
+export function Fieldset(props: FieldsetProps) {
+  return <fieldset {...props} />
+}
+
+export type LegendProps = React.ComponentPropsWithoutRef<'legend'>
+export function Legend(props: LegendProps) {
+  return <legend {...props} />
+}
+
+export type LabelProps<T extends ElementType = 'label'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+
+export const Label = forwardRef(function Label<T extends ElementType = 'label'>(
+  { as, ...props }: LabelProps<T>,
+  ref: Ref<Element>,
+) {
+  let Component = (as ?? 'label') as ElementType
+  return <Component {...(props as Record<string, unknown>)} ref={ref} />
+}) as <T extends ElementType = 'label'>(
+  props: LabelProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+export type SwitchProps = React.ComponentPropsWithoutRef<'button'> & {
+  checked?: boolean
+  onChange?(value: boolean): void
+}
+
+export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch(
+  { checked = false, onChange, onClick, ...props },
+  ref,
+) {
+  let handleClick = composeEventHandlers<React.MouseEvent<HTMLButtonElement>>(
+    () => {
+      onChange?.(!checked)
+    },
+    onClick,
+  )
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      {...props}
+      ref={ref}
+      onClick={handleClick}
+    />
+  )
+})
+
+export type CheckboxProps = React.ComponentPropsWithoutRef<'input'>
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  { type, ...props },
+  ref,
+) {
+  return <input {...props} ref={ref} type="checkbox" />
+})
+
+export type RadioProps = React.ComponentPropsWithoutRef<'input'>
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio({ type, ...props }, ref) {
+  return <input {...props} ref={ref} type="radio" />
+})
+
+export type TextFieldProps = React.ComponentPropsWithoutRef<'input'>
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function TextField(
+  props,
+  ref,
+) {
+  return <input {...props} ref={ref} />
+})
+
+export type TextareaProps = React.ComponentPropsWithoutRef<'textarea'>
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  props,
+  ref,
+) {
+  return <textarea {...props} ref={ref} />
+})
+
+export type ComboboxProps<T extends ElementType = 'input'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+export const Combobox = forwardRef(function Combobox<T extends ElementType = 'input'>(
+  { as, ...props }: ComboboxProps<T>,
+  ref: Ref<Element>,
+) {
+  let Component = (as ?? 'input') as ElementType
+  return <Component {...(props as Record<string, unknown>)} ref={ref} />
+}) as <T extends ElementType = 'input'>(
+  props: ComboboxProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+export type ListboxProps<T extends ElementType = 'ul'> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+export const Listbox = forwardRef(function Listbox<T extends ElementType = 'ul'>(
+  { as, ...props }: ListboxProps<T>,
+  ref: Ref<Element>,
+) {
+  let Component = (as ?? 'ul') as ElementType
+  return <Component {...(props as Record<string, unknown>)} ref={ref} />
+}) as <T extends ElementType = 'ul'>(
+  props: ListboxProps<T> & { ref?: Ref<Element> },
+) => ReactElement | null
+
+export type TransitionProps = PropsWithChildren<{
+  show?: boolean
+}>
+export function Transition({ show = true, children }: TransitionProps) {
+  if (!show) {
+    return null
+  }
+  return <>{children}</>
+}

--- a/lib/motion.tsx
+++ b/lib/motion.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import React, { forwardRef, type ElementType, type PropsWithChildren, type Ref } from 'react'
+
+export function LayoutGroup({ children }: PropsWithChildren<{ id?: string }>) {
+  return <>{children}</>
+}
+
+type MotionComponentProps<T extends ElementType> = {
+  as?: T
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>
+
+type MotionComponent = <T extends ElementType = 'span'>(
+  props: MotionComponentProps<T> & { ref?: Ref<Element> },
+) => React.ReactElement | null
+
+function createMotionComponent<Tag extends ElementType>(tag: Tag): MotionComponent {
+  return forwardRef(function MotionComponentInternal<T extends ElementType = Tag>(
+    { as, ...props }: MotionComponentProps<T>,
+    ref: Ref<Element>,
+  ) {
+    let Component = (as ?? tag) as ElementType
+    return <Component {...(props as Record<string, unknown>)} ref={ref} />
+  }) as MotionComponent
+}
+
+export const motion: { span: MotionComponent } = {
+  span: createMotionComponent('span'),
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
@@ -8,6 +10,16 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+  },
+  webpack(config) {
+    config.resolve = config.resolve ?? {}
+    config.resolve.alias = {
+      ...(config.resolve.alias ?? {}),
+      '@headlessui/react': path.join(process.cwd(), 'lib', 'headlessui.tsx'),
+      'motion/react': path.join(process.cwd(), 'lib', 'motion.tsx'),
+    }
+
+    return config
   },
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@headlessui/react": ["./lib/headlessui"],
+      "motion/react": ["./lib/motion"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add an in-repo replacement for the `@headlessui/react` primitives used by the Catalyst layout
- provide a lightweight shim for `motion/react` and wire both shims through the TypeScript and webpack aliases
- mark the home page as dynamic to keep the Next.js build from timing out when pre-rendering it

## Testing
- CI=1 npm run build
- npm run lint *(fails: ESLint must be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc93e3e8c0832484687c99473dce21