### PR TITLE
Fix dev server crash by making home page client component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 export const dynamic = "force-dynamic"
 
 import OpsCatalog from "@/components/ops-catalog"


### PR DESCRIPTION
## Summary
- mark `app/page.tsx` as a client component so Next.js no longer serializes the navbar and sidebar React nodes on the server

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ccad43187483248701119cdd158537