### PR TITLE
Fix DropdownLabel prop ordering

### DIFF
--- a/components/dropdown.tsx
+++ b/components/dropdown.tsx
@@ -136,7 +136,7 @@ export function DropdownDivider({
 }
 
 export function DropdownLabel({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
-  return <div {...props} data-slot="label" className={clsx(className, 'col-start-2 row-start-1')} {...props} />
+  return <div {...props} data-slot="label" className={clsx(className, 'col-start-2 row-start-1')} />
 }
 
 export function DropdownDescription({


### PR DESCRIPTION
## Summary
- remove the redundant prop spread from `DropdownLabel` so the computed label styling is preserved

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccb6c4cdb48324b2413a2d9479f014