### PR TITLE
Clean up operations catalog navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,22 @@
+"use client"
+
+import { useState } from "react"
+
 import OpsCatalog from "@/components/ops-catalog"
 import { DashboardShell } from "@/components/dashboard-shell"
 
 export default function Home() {
+  const [query, setQuery] = useState("")
+
   return (
-    <DashboardShell>
-      <OpsCatalog />
+    <DashboardShell
+      search={{
+        value: query,
+        onChange: setQuery,
+        placeholder: "Search categories or SOPs…",
+      }}
+    >
+      <OpsCatalog query={query} />
     </DashboardShell>
   )
 }

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -219,11 +219,18 @@ function DashboardSidebar() {
   )
 }
 
-interface DashboardShellProps {
-  children: ReactNode
+interface DashboardShellSearchProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
 }
 
-export function DashboardShell({ children }: DashboardShellProps) {
+interface DashboardShellProps {
+  children: ReactNode
+  search?: DashboardShellSearchProps
+}
+
+export function DashboardShell({ children, search }: DashboardShellProps) {
   return (
     <SidebarProvider>
       <div className="flex min-h-screen w-full bg-muted/20">
@@ -243,14 +250,23 @@ export function DashboardShell({ children }: DashboardShellProps) {
                 </p>
               </div>
               <div className="flex flex-1 items-center gap-2 md:justify-end">
-                <div className="relative w-full max-w-xs">
-                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    className="h-9 w-full pl-9"
-                    placeholder="Search processes..."
-                    type="search"
-                  />
-                </div>
+                {search ? (
+                  <div className="relative w-full max-w-xs">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      className="h-9 w-full pl-9"
+                      placeholder={search.placeholder ?? "Search categories or SOPs…"}
+                      type="search"
+                      value={search.value}
+                      onChange={(event) => search.onChange(event.target.value)}
+                    />
+                  </div>
+                ) : (
+                  <div className="relative w-full max-w-xs">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input className="h-9 w-full pl-9" placeholder="Search processes..." type="search" />
+                  </div>
+                )}
                 <Button size="sm" className="hidden sm:inline-flex">
                   <Plus className="mr-2 h-4 w-4" />
                   New process

--- a/components/ops-catalog.tsx
+++ b/components/ops-catalog.tsx
@@ -20,7 +20,6 @@ import {
   Minimize2,
   Pencil,
   Plus,
-  Search,
   Settings,
   Trash2,
 } from "lucide-react"
@@ -86,6 +85,10 @@ type Category = {
 type SlashMenuPosition = {
   top: number
   left: number
+}
+
+interface OpsCatalogProps {
+  query: string
 }
 
 const SAMPLE_DATA: Category[] = [
@@ -1071,8 +1074,7 @@ const filterData = (data: Category[], query: string) => {
     .filter((category): category is Category => Boolean(category))
 }
 
-export default function OpsCatalog() {
-  const [query, setQuery] = useState("")
+export default function OpsCatalog({ query }: OpsCatalogProps) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [selectedSOP, setSelectedSOP] = useState<Sop | null>(null)
   const [data, setData] = useState<Category[]>(SAMPLE_DATA)
@@ -1427,21 +1429,6 @@ Describe the goal of the procedure.
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-4">
-          <div className="text-xl font-semibold">Standard Operating Procedures</div>
-          <div className="relative ml-auto w-full max-w-md">
-            <Search className="pointer-events-none absolute left-3 top-2.5 h-5 w-5 text-gray-400" />
-            <input
-              className="w-full rounded-xl border py-2 pl-10 pr-3 text-sm focus:outline-none focus:ring-2"
-              placeholder="Search categories or SOPs…"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-            />
-          </div>
-        </div>
-      </div>
-
       <div
         className={cn(
           "mx-auto grid max-w-6xl gap-6 px-4 py-6",


### PR DESCRIPTION
## Summary
- remove the catalog's internal SOP toolbar and take the search query as a prop instead
- expose configurable search controls in the dashboard shell header and bind them to the catalog query
- manage the catalog search state in the home page so the header search filters results

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cd78b365a4832499acec8d1a79fb53