### PR TITLE
Fix ProcessEditor formatting commands and focus outline

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -89,6 +89,11 @@
   body {
     @apply bg-background text-foreground;
   }
+  [contenteditable]:focus,
+  [contenteditable]:focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
   [data-nextjs-dev-tools-button],
   [data-next-badge],
   [data-next-badge-root],


### PR DESCRIPTION
## Summary
- preserve the editor selection so heading, list, and quote actions execute on the expected text
- restore the saved selection before inserting custom checklist, callout, code, AI prompt, and link blocks
- remove the default focus outline from the content editable surface to avoid the blue border when focusing the editor

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2be7d90c8324927c0b76fcd9d184