### PR TITLE
Fix process editor formatting controls

### DIFF
--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -11,10 +11,13 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
-    className={cn('relative overflow-hidden', className)}
+    className={cn(
+      'relative overflow-hidden focus:outline-none focus-visible:outline-none',
+      className,
+    )}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] focus:outline-none focus-visible:outline-none">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -94,6 +94,25 @@
     outline: none;
     box-shadow: none;
   }
+  .process-editor-content h1 {
+    @apply text-2xl font-bold leading-tight tracking-tight;
+  }
+  .process-editor-content h2 {
+    @apply text-xl font-semibold leading-snug;
+  }
+  .process-editor-content ol {
+    @apply list-decimal space-y-2 pl-6;
+  }
+  .process-editor-content ul:not(.process-checklist) {
+    @apply list-disc space-y-2 pl-6;
+  }
+  .process-editor-content ol li,
+  .process-editor-content ul li {
+    @apply pl-1;
+  }
+  .process-editor-content blockquote {
+    @apply border-l-4 border-border/60 bg-muted/40 px-4 py-3 italic text-muted-foreground;
+  }
   [data-nextjs-dev-tools-button],
   [data-next-badge],
   [data-next-badge-root],


### PR DESCRIPTION
## Summary
- style headings, lists, and quotes rendered inside the process editor so toolbar actions visibly format content
- remove focus outlines from the scroll area viewport to keep the editor free of blue borders while typing

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2eb73f888324b23c6fa045b50308