### PR TITLE
Sync one-time process deadline from workflow nodes

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,21 @@ export interface Task {
   nodeId: string | null
 }
 
+export type ProcessDeadline =
+  | {
+      type: "relative"
+      value: string
+      unit: "hours" | "days"
+      nodeId: string
+      nodeLabel?: string
+    }
+  | {
+      type: "absolute"
+      value: string
+      nodeId: string
+      nodeLabel?: string
+    }
+
 export interface NodeData {
   label: string
   description?: string

--- a/lib/workflow-utils.ts
+++ b/lib/workflow-utils.ts
@@ -1,5 +1,5 @@
 import type { Node, XYPosition } from "reactflow"
-import type { NodeData } from "./types"
+import type { NodeData, ProcessDeadline } from "./types"
 
 let nodeIdCounter = 0
 
@@ -129,4 +129,25 @@ const getDefaultDescription = (type: string): string => {
     default:
       return "Workflow node"
   }
+}
+
+export const deadlinesAreEqual = (
+  a: ProcessDeadline | null,
+  b: ProcessDeadline | null,
+): boolean => {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.type !== b.type) return false
+  if (a.nodeId !== b.nodeId) return false
+  if ((a.nodeLabel ?? "") !== (b.nodeLabel ?? "")) return false
+
+  if (a.type === "absolute" && b.type === "absolute") {
+    return a.value === b.value
+  }
+
+  if (a.type === "relative" && b.type === "relative") {
+    return a.value === b.value && a.unit === b.unit
+  }
+
+  return false
 }


### PR DESCRIPTION
## Summary
- add a ProcessDeadline type and equality helper used across the workflow builder and settings
- surface the last configured process node's deadline selection to the Process Settings one-time tab
- persist synced deadlines on the selected SOP and display a formatted summary with source information

## Testing
- pnpm lint *(fails: ESLint must be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01b9bb2d48324a14e1b1f7c64432d