### PR TITLE
fix: stabilize workflow update handler

### DIFF
--- a/components/workflow-builder.tsx
+++ b/components/workflow-builder.tsx
@@ -31,7 +31,13 @@ import { ConditionalNode } from "./nodes/conditional-node"
 import { CodeNode } from "./nodes/code-node"
 import { generateNodeId, createNode, deadlinesAreEqual } from "@/lib/workflow-utils"
 import { cn } from "@/lib/utils"
-import type { Task, WorkflowNode, NodeData, ProcessDeadline } from "@/lib/types"
+import type {
+  Task,
+  WorkflowNode,
+  NodeData,
+  ProcessDeadline,
+  Workflow,
+} from "@/lib/types"
 
 const nodeTypes: NodeTypes = {
   input: InputNode,
@@ -148,6 +154,7 @@ type WorkflowBuilderProps = {
   onUpdateTaskDueDate?: (taskId: number, due: string) => void
   onMarkTaskDone?: (taskId: number) => void
   onLastProcessDeadlineChange?: (deadline: ProcessDeadline | null) => void
+  onWorkflowUpdate?: (workflow: Workflow) => void
 }
 
 export default function WorkflowBuilder({
@@ -159,6 +166,7 @@ export default function WorkflowBuilder({
   onUpdateTaskDueDate,
   onMarkTaskDone,
   onLastProcessDeadlineChange,
+  onWorkflowUpdate,
 }: WorkflowBuilderProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null)
   const [nodes, setNodes, onNodesChange] = useNodesState([])
@@ -307,6 +315,14 @@ export default function WorkflowBuilder({
       setSelectedNode(updated)
     }
   }, [nodes, selectedNode])
+
+  useEffect(() => {
+    if (!onWorkflowUpdate) {
+      return
+    }
+
+    onWorkflowUpdate({ nodes, edges })
+  }, [nodes, edges, onWorkflowUpdate])
 
   useEffect(() => {
     if (!onLastProcessDeadlineChange) {


### PR DESCRIPTION
## Summary
- track workflow updates from the process designer so the processor portal can mirror the configured nodes
- replace the processor portal view with a calendar-based schedule plus process task table that surfaces assignments, deadlines, outputs, and completion logs
- reset workflow context when switching processes to keep the portal in sync
- stabilize the workflow update handler so the processor portal no longer re-renders in an infinite loop

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d020c7ac388324933f8dfe2de3fa24