### PR TITLE
Add interactive output submission controls to Processor Portal

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,17 @@ export interface Task {
   nodeId: string | null
 }
 
+export type OutputRequirementType = "markDone" | "file" | "link" | "text"
+
+export interface OutputSubmission {
+  nodeId: string
+  type: OutputRequirementType
+  value: string
+  fileName?: string
+  completedBy: string
+  completedAt: string
+}
+
 export type ProcessDeadline =
   | {
       type: "relative"
@@ -54,7 +65,7 @@ export interface NodeData {
   reminderEnabled?: boolean
   reminderLeadTime?: string
   reminderLeadTimeUnit?: "hours" | "days"
-  outputRequirementType?: "markDone" | "file" | "link" | "text"
+  outputRequirementType?: OutputRequirementType
   outputStructuredDataTemplate?: string
   validationRequireOutput?: boolean
   validationNotes?: string


### PR DESCRIPTION
## Summary
- add output submission types and a current processor constant to support tracking completions
- store per-node output submissions in OpsCatalog and reset them when switching processes
- render interactive output requirement actions in the Processor Portal table and schedule cards while updating completion logs and status badges

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1635dde3c8324a99040cab898267f