### PR TITLE
Revamp process calendar controls

### DIFF
--- a/components/node-config-panel.tsx
+++ b/components/node-config-panel.tsx
@@ -298,6 +298,7 @@ export default function NodeConfigPanel({ node, updateNodeData, onClose }: NodeC
                     <div className="ml-6 mt-2 space-y-3">
                       <Calendar
                         mode="single"
+                        captionLayout="dropdown-buttons"
                         defaultMonth={deadlineAbsoluteDate ?? new Date()}
                         selected={deadlineAbsoluteDate}
                         onSelect={handleAbsoluteDateChange}

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -66,22 +66,22 @@ function Calendar({
           defaultClassNames.month_caption,
         ),
         dropdowns: cn(
-          'w-full flex items-center text-sm font-medium justify-center h-[--cell-size] gap-1.5',
+          'w-full flex items-center justify-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground',
           defaultClassNames.dropdowns,
         ),
         dropdown_root: cn(
-          'relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md',
+          'relative isolate flex h-8 min-w-[6.5rem] items-center justify-center rounded-full border border-transparent bg-muted/50 px-3 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground transition focus-within:border-ring focus-within:bg-background focus-within:text-foreground focus-within:shadow-[0_0_0_1px_rgba(var(--ring),0.15)] focus-within:ring-2 focus-within:ring-ring/30',
           defaultClassNames.dropdown_root,
         ),
         dropdown: cn(
-          'absolute bg-popover inset-0 opacity-0',
+          'absolute inset-0 h-full w-full cursor-pointer opacity-0',
           defaultClassNames.dropdown,
         ),
         caption_label: cn(
-          'select-none font-medium',
+          'select-none font-medium transition-colors',
           captionLayout === 'label'
             ? 'text-sm'
-            : 'rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5',
+            : 'pointer-events-none flex h-full items-center gap-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground [&>svg]:size-3 [&>svg]:text-muted-foreground group-focus-within/calendar:text-foreground',
           defaultClassNames.caption_label,
         ),
         table: 'w-full border-collapse',

--- a/components/workflow-builder.tsx
+++ b/components/workflow-builder.tsx
@@ -535,7 +535,7 @@ export default function WorkflowBuilder({
         </div>
 
         {selectedNode && (
-          <div className="w-[28rem] border-l border-gray-200 p-4 bg-gray-50">
+          <div className="w-[calc(28rem+12px)] border-l border-gray-200 p-4 bg-gray-50">
             <NodeConfigPanel
               node={selectedNode as WorkflowNode}
               updateNodeData={updateNodeData}


### PR DESCRIPTION
## Summary
- restyle the calendar dropdown controls to better match the panel styling
- enable dropdown navigation on the process deadline calendar and widen the config drawer for additional space

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b67d0f8483248291b25852235489