### PR TITLE
Revamp input process start triggers

### DIFF
--- a/components/nodes/input-node.tsx
+++ b/components/nodes/input-node.tsx
@@ -2,14 +2,28 @@
 
 import { memo } from "react"
 import { Handle, Position, type NodeProps } from "reactflow"
-import { Database } from "lucide-react"
+import { CalendarClock } from "lucide-react"
 import type { NodeData } from "@/lib/types"
+import { describeInputStartTrigger } from "@/lib/workflow-utils"
 export const InputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) => {
+  const triggerDescription = describeInputStartTrigger(data)
+  const triggerTypeLabel = (() => {
+    switch (data.startTriggerType) {
+      case "process":
+        return "Process dependency"
+      case "serviceDesk":
+        return "Service desk trigger"
+      case "schedule":
+      default:
+        return "Scheduled start"
+    }
+  })()
+
   return (
     <div className="px-4 py-2 shadow-md rounded-md bg-white border-2 border-blue-500 min-w-[150px]">
       <div className="flex items-center">
         <div className="rounded-full w-8 h-8 flex items-center justify-center bg-blue-100 text-blue-500">
-          <Database className="h-4 w-4" />
+          <CalendarClock className="h-4 w-4" />
         </div>
         <div className="ml-2">
           <div className="text-sm font-bold">{data.label || "Input"}</div>
@@ -19,11 +33,14 @@ export const InputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>)
         </div>
       </div>
 
-      {data.dataSource && (
-        <div className="mt-2 text-xs bg-gray-100 p-1 rounded">
-          Source: {data.dataSource}
+      {triggerDescription ? (
+        <div className="mt-3 space-y-1 text-xs">
+          <span className="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 font-semibold text-blue-600">
+            {triggerTypeLabel}
+          </span>
+          <p className="text-gray-500">{triggerDescription}</p>
         </div>
-      )}
+      ) : null}
 
       <Handle
         type="source"

--- a/components/ops-catalog.tsx
+++ b/components/ops-catalog.tsx
@@ -70,7 +70,7 @@ import {
 import WorkflowBuilder from "./workflow-builder"
 import { ProcessEditor, extractPlainText } from "./process-editor"
 import { cn } from "@/lib/utils"
-import { deadlinesAreEqual } from "@/lib/workflow-utils"
+import { deadlinesAreEqual, describeInputStartTrigger } from "@/lib/workflow-utils"
 import type {
   ProcessDeadline,
   Task,
@@ -1375,9 +1375,7 @@ const CalendarView = ({
   const inputDescription =
     primaryInput?.description ||
     "Add an input node in the Process Designer to describe what processors receive."
-  const inputSourceNote = primaryInput?.dataSource
-    ? `Source: ${primaryInput.dataSource}`
-    : null
+  const inputTriggerNote = primaryInput ? describeInputStartTrigger(primaryInput) : null
 
   const outputLabel = primaryOutput?.label || "Output"
   const outputDescription =
@@ -1645,8 +1643,8 @@ const CalendarView = ({
                 {inputLabel}
               </span>
               <p className="text-sm text-foreground">{inputDescription}</p>
-              {inputSourceNote ? (
-                <p className="text-xs text-muted-foreground">{inputSourceNote}</p>
+              {inputTriggerNote ? (
+                <p className="text-xs text-muted-foreground">Start trigger: {inputTriggerNote}</p>
               ) : null}
             </div>
             <div className="space-y-2">

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -42,8 +42,11 @@ export interface NodeData {
   required?: boolean
 
   // Input node properties
-  dataSource?: "manual" | "api" | "database" | "file"
-  sampleData?: string
+  startTriggerType?: "schedule" | "process" | "serviceDesk"
+  startTriggerScheduledAt?: string
+  startTriggerProcessCategory?: string
+  startTriggerProcessId?: string
+  startTriggerServiceDeskRequests?: string[]
 
   // Output node properties
   outputType?: "console" | "api" | "database" | "file"


### PR DESCRIPTION
## Summary
- replace legacy input node data-source controls with scheduling, process dependency, and service desk trigger options including calendar/time selection and contextual dropdowns
- surface the selected start trigger in the input node badge and Ops Catalog overview using a shared formatter
- extend workflow node typing and defaults to capture start trigger details

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bb68b7248324b0e6f9f023ed85e9