### PR TITLE
Revamp output process node options

### DIFF
--- a/components/nodes/output-node.tsx
+++ b/components/nodes/output-node.tsx
@@ -4,7 +4,14 @@ import { memo } from "react"
 import { Handle, Position, type NodeProps } from "reactflow"
 import { FileOutput } from "lucide-react"
 import type { NodeData } from "@/lib/types"
+import {
+  describeOutputAlerts,
+  describeOutputCompletion,
+} from "@/lib/workflow-utils"
 export const OutputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>) => {
+  const completionNote = describeOutputCompletion(data)
+  const alertsNote = describeOutputAlerts(data.outputAlertChannels)
+
   return (
     <div className="px-4 py-2 shadow-md rounded-md bg-white border-2 border-green-500 min-w-[150px]">
       <div className="flex items-center">
@@ -19,11 +26,14 @@ export const OutputNode = memo(({ id, data, isConnectable }: NodeProps<NodeData>
         </div>
       </div>
 
-      {data.outputType && (
-        <div className="mt-2 text-xs bg-gray-100 p-1 rounded">
-          Output: {data.outputType} ({data.outputFormat || "json"})
-        </div>
-      )}
+      <div className="mt-2 space-y-1">
+        <div className="text-xs bg-gray-100 p-1 rounded">{completionNote}</div>
+        {alertsNote ? (
+          <div className="text-xs bg-blue-50 text-blue-600 p-1 rounded">
+            {alertsNote}
+          </div>
+        ) : null}
+      </div>
 
       <Handle
         type="target"

--- a/components/ops-catalog.tsx
+++ b/components/ops-catalog.tsx
@@ -70,7 +70,12 @@ import {
 import WorkflowBuilder from "./workflow-builder"
 import { ProcessEditor, extractPlainText } from "./process-editor"
 import { cn } from "@/lib/utils"
-import { deadlinesAreEqual, describeInputStartTrigger } from "@/lib/workflow-utils"
+import {
+  deadlinesAreEqual,
+  describeInputStartTrigger,
+  describeOutputAlerts,
+  describeOutputCompletion,
+} from "@/lib/workflow-utils"
 import type {
   ProcessDeadline,
   Task,
@@ -1381,10 +1386,11 @@ const CalendarView = ({
   const outputDescription =
     primaryOutput?.description ||
     "Add an output node to capture the expected deliverable for this process."
-  const outputFormatNote = primaryOutput?.outputType
-    ? `Output: ${primaryOutput.outputType}${
-        primaryOutput.outputFormat ? ` (${primaryOutput.outputFormat})` : ""
-      }`
+  const outputCompletionNote = primaryOutput
+    ? describeOutputCompletion(primaryOutput)
+    : null
+  const outputAlertsNote = primaryOutput
+    ? describeOutputAlerts(primaryOutput.outputAlertChannels)
     : null
 
   return (
@@ -1652,8 +1658,11 @@ const CalendarView = ({
                 {outputLabel}
               </span>
               <p className="text-sm text-foreground">{outputDescription}</p>
-              {outputFormatNote ? (
-                <p className="text-xs text-muted-foreground">{outputFormatNote}</p>
+              {outputCompletionNote ? (
+                <p className="text-xs text-muted-foreground">{outputCompletionNote}</p>
+              ) : null}
+              {outputAlertsNote ? (
+                <p className="text-xs text-muted-foreground">{outputAlertsNote}</p>
               ) : null}
             </div>
           </div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,8 @@ export interface Task {
   nodeId: string | null
 }
 
+export type OutputCompletionType = "markDone" | "scheduled"
+export type OutputAlertChannel = "slack" | "teams" | "email"
 export type OutputRequirementType = "markDone" | "file" | "link" | "text"
 
 export interface OutputSubmission {
@@ -49,8 +51,9 @@ export interface NodeData {
   startTriggerServiceDeskRequests?: string[]
 
   // Output node properties
-  outputType?: "console" | "api" | "database" | "file"
-  outputFormat?: "json" | "csv" | "xml" | "text"
+  outputCompletionType?: OutputCompletionType
+  outputCompletionScheduledAt?: string
+  outputAlertChannels?: OutputAlertChannel[]
 
   // Process node properties
   assignmentType?: "user" | "role"


### PR DESCRIPTION
## Summary
- replace the output node configuration with completion triggers and alert channel selections
- extend workflow utilities and types to describe the new output completion and alert metadata
- refresh output node and Ops catalog summaries to surface the new completion and alert details

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ca87c978832495f5795510f72901