### PR TITLE
Add dedicated account settings navigation

### DIFF
--- a/app/account-settings/page.tsx
+++ b/app/account-settings/page.tsx
@@ -25,6 +25,12 @@ import { Switch } from "@/components/ui/switch"
 
 type NotificationChannel = "slack" | "teams" | "email"
 
+type NotificationChannelOption = {
+  id: NotificationChannel
+  label: string
+  description: string
+}
+
 type TeamOption = {
   id: string
   name: string
@@ -47,6 +53,12 @@ const TIMEZONE_OPTIONS: TimezoneOption[] = [
   { value: "America/Chicago", label: "Central Time (US/Central)" },
   { value: "America/Los_Angeles", label: "Pacific Time (US/Pacific)" },
   { value: "Europe/London", label: "Greenwich Mean Time (Europe/London)" },
+]
+
+const NOTIFICATION_CHANNELS: NotificationChannelOption[] = [
+  { id: "slack", label: "Slack", description: "Send direct alerts to #process-ops." },
+  { id: "teams", label: "Microsoft Teams", description: "Notify dedicated responders in Teams." },
+  { id: "email", label: "Email", description: "Receive daily digests and assignments." },
 ]
 
 export default function AccountSettingsPage() {
@@ -195,15 +207,7 @@ export default function AccountSettingsPage() {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-3">
-                {([
-                  { id: "slack", label: "Slack", description: "Send direct alerts to #process-ops." },
-                  { id: "teams", label: "Microsoft Teams", description: "Notify dedicated responders in Teams." },
-                  { id: "email", label: "Email", description: "Receive daily digests and assignments." },
-                ] as {
-                  id: NotificationChannel
-                  label: string
-                  description: string
-                }[]).map((channel) => (
+                {NOTIFICATION_CHANNELS.map((channel) => (
                   <div
                     key={channel.id}
                     className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3"

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { usePathname, useRouter } from "next/navigation"
+import { usePathname } from "next/navigation"
 import { type ReactNode } from "react"
 import {
   BarChart3,
@@ -142,8 +142,6 @@ const teams: { name: string; plan: string; initials: string; url: string }[] = [
 
 function DashboardSidebar() {
   const pathname = usePathname()
-  const router = useRouter()
-
   const isMatchingPath = (target: string) => {
     if (target === "/") {
       return pathname === "/"
@@ -297,9 +295,11 @@ function DashboardSidebar() {
                     <Sparkles className="h-4 w-4" />
                     Upgrade to Pro
                   </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => router.push("/account-settings")}>
-                    <User className="h-4 w-4" />
-                    Account
+                  <DropdownMenuItem asChild>
+                    <Link href="/account-settings" className="flex items-center gap-2">
+                      <User className="h-4 w-4" />
+                      Account
+                    </Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem>
                     <LogOut className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- extract notification channel configuration into a shared constant on the account settings page
- hook the sidebar account dropdown item directly to the /account-settings route

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d34f62c52083249e9751315b3cf758