### PR TITLE
Tighten Supabase RBAC policies and examples

### DIFF
--- a/docs/supabase-auth-setup.md
+++ b/docs/supabase-auth-setup.md
@@ -1,0 +1,72 @@
+# Supabase authentication and RBAC quick-start
+
+This guide explains how to prepare your Supabase project so that Google and Email + Password authentication is enabled, roles/org memberships are stored in `auth.users.app_metadata`, and JWT claims can be used from both your frontend and Row Level Security (RLS) policies.
+
+## 1. Enable authentication providers
+
+1. Open the Supabase dashboard for your project.
+2. Navigate to **Authentication → Providers**.
+3. Enable **Email** provider. This enables password-based sign-ups/logins.
+4. Enable **Google** provider and supply the OAuth Client ID/Secret generated from the Google Cloud Console.
+5. Save the provider configuration.
+
+These steps ensure users can sign up with either email/password or Google. Supabase will include any `app_metadata` and `user_metadata` fields you set on the user inside the access token (JWT) that your frontend receives.
+
+## 2. Apply the database migration
+
+Run the SQL in `supabase/migrations/0001_auth_rbac.sql` against your project (via the Supabase SQL editor or `supabase db push`). If you have not already linked the CLI, run `supabase link --project-ref <your-project-ref>` from the repository root so future pushes reuse the connection. The migration creates:
+
+- `public.organisations`: canonical list of tenant organisations.
+- `public.processes`: example multi-tenant data model.
+- Timestamp trigger function for consistent `updated_at` columns.
+- Row Level Security policies that enforce permissions using JWT claims (`role` and `org_id`). Each policy starts with `drop policy if exists` so the migration stays idempotent when re-run locally.
+
+After running the migration, keep RLS **enabled** on both tables. The policies expect JWTs to contain `app_metadata.role` and `app_metadata.org_id` claims for every authenticated user.
+
+## 3. Managing user roles and organisations
+
+Use the Supabase Admin API (service role key) to set the `app_metadata` for users after they sign up. The example code in [`examples/supabase-auth.ts`](../examples/supabase-auth.ts) shows how to:
+
+- Listen for signups (e.g. from a serverless function or webhook).
+- Upsert an organisation when necessary.
+- Store `role` (`superuser`, `admin`, or `user`) and the organisation UUID in `user.app_metadata`.
+
+Every authenticated request will now include the role/org claims inside the JWT, making them available to both RLS policies and frontend code.
+
+## 4. Reading JWT claims in the frontend
+
+Your frontend can read the role and organisation with the Supabase client (`supabase.auth.getUser()` or `onAuthStateChange`). The `user` object exposes `app_metadata.role` and `app_metadata.org_id`, matching what the RLS policies expect.
+
+```ts
+const {
+  data: { user },
+  error,
+} = await supabase.auth.getUser();
+
+if (error) throw error;
+
+const role = user?.app_metadata?.role; // 'superuser' | 'admin' | 'user'
+const orgId = user?.app_metadata?.org_id as string | undefined;
+```
+
+## 5. Using JWT claims in SQL / RLS
+
+Inside Postgres policies, Supabase exposes the decoded JWT via `auth.jwt()`. The migration demonstrates how to inspect nested claims:
+
+```sql
+(auth.jwt() -> 'app_metadata' ->> 'role') = 'admin'
+(auth.jwt() -> 'app_metadata' ->> 'org_id')::uuid
+```
+
+These expressions keep your policies aligned with the values your frontend reads. Superusers bypass tenant scoping, while admins and users are limited to the organisation encoded in the JWT.
+
+## 6. Testing the access control
+
+1. Create three users and assign them the roles `superuser`, `admin`, and `user`, each with an `app_metadata.org_id` referencing an existing organisation row.
+2. Authenticate with each account and call Supabase from your frontend or the SQL editor (using the JWT as a bearer token).
+3. Verify:
+   - The superuser can select/insert/update/delete from any organisation or process.
+   - The admin can only manipulate rows where `org_id` matches their `app_metadata.org_id`.
+   - The user can select, insert, and update processes from their own organisation, cannot delete processes, and can only view their own organisation record.
+
+When these tests pass you have a minimal working auth + RBAC foundation that you can extend with more tables following the same policy pattern.

--- a/examples/supabase-auth.ts
+++ b/examples/supabase-auth.ts
@@ -1,0 +1,98 @@
+import { createClient, type User } from '@supabase/supabase-js';
+
+/**
+ * Configure Supabase clients. The admin client must use the service role key so it can
+ * bypass RLS when provisioning organisations and updating user app_metadata.
+ */
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseServiceRoleKey || !supabaseAnonKey) {
+  throw new Error(
+    'Missing Supabase environment variables. Ensure NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY are set.',
+  );
+}
+
+export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceRoleKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false,
+  },
+});
+
+type Role = 'superuser' | 'admin' | 'user';
+
+type AssignUserRoleInput = {
+  userId: string;
+  role: Role;
+  orgId: string; // UUID from public.organisations
+};
+
+/**
+ * Ensures an organisation exists (idempotent) and returns its row.
+ */
+export async function ensureOrganisation(name: string) {
+  const { data, error } = await supabaseAdmin
+    .from('organisations')
+    .upsert({ name }, { onConflict: 'name' })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Updates a user's app_metadata with role/org claims so they appear in JWTs.
+ */
+export async function assignUserRole({ userId, role, orgId }: AssignUserRoleInput) {
+  const { data, error } = await supabaseAdmin.auth.admin.updateUserById(userId, {
+    app_metadata: {
+      role,
+      org_id: orgId,
+    },
+  });
+
+  if (error) throw error;
+  return data.user;
+}
+
+/**
+ * Example handler that could be triggered from a Supabase "auth.user.created" webhook.
+ */
+export async function handleNewSignup(user: User) {
+  // 1. Determine which organisation + role the new user should belong to.
+  // This could be based on invite tokens, signup form data, etc.
+  const organisation = await ensureOrganisation('Acme Inc.');
+
+  // 2. Decide the correct role for the user.
+  const role: Role = user.email?.endsWith('@acme.example') ? 'admin' : 'user';
+
+  // 3. Persist role/org in app_metadata so RLS policies recognise them.
+  await assignUserRole({ userId: user.id, role, orgId: organisation.id });
+}
+
+/**
+ * Frontend helper: read the role + organisation for the current session.
+ */
+export async function getCurrentUserClaims() {
+  const client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+    },
+  });
+
+  const {
+    data: { user },
+    error,
+  } = await client.auth.getUser();
+
+  if (error) throw error;
+
+  return {
+    role: user?.app_metadata?.role as Role | undefined,
+    orgId: user?.app_metadata?.org_id as string | undefined,
+  };
+}

--- a/supabase/migrations/0001_auth_rbac.sql
+++ b/supabase/migrations/0001_auth_rbac.sql
@@ -1,0 +1,160 @@
+-- 0001_auth_rbac.sql
+-- Migration to set up organisations/processes tables with RBAC-aware RLS policies.
+
+-- Enable required extensions.
+create extension if not exists "pgcrypto";
+
+-- Organisations table keeps a canonical list of tenants.
+create table if not exists public.organisations (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  slug text generated always as (lower(regexp_replace(name, '[^a-z0-9]+', '-', 'g'))) stored,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  created_by uuid references auth.users (id) on delete set null,
+  updated_by uuid references auth.users (id) on delete set null
+);
+
+comment on table public.organisations is 'Tenants that Supabase roles and policies reference.';
+
+-- Processes belong to an organisation.
+create table if not exists public.processes (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organisations (id) on delete cascade,
+  name text not null,
+  description text,
+  status text not null default 'draft',
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  created_by uuid references auth.users (id) on delete set null,
+  updated_by uuid references auth.users (id) on delete set null
+);
+
+comment on table public.processes is 'Sample table showing per-organisation access control.';
+
+-- Automatically manage updated_at timestamps.
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists organisations_set_updated_at on public.organisations;
+create trigger organisations_set_updated_at
+before update on public.organisations
+for each row
+execute function public.set_updated_at();
+
+drop trigger if exists processes_set_updated_at on public.processes;
+create trigger processes_set_updated_at
+before update on public.processes
+for each row
+execute function public.set_updated_at();
+
+-- Enable RLS so that policies apply.
+alter table public.organisations enable row level security;
+alter table public.processes enable row level security;
+
+-- Convenience helper expressions reused in policies are expressed inline.
+-- JWT claims are expected under auth.jwt()->'app_metadata'.
+
+drop policy if exists organisations_superuser_manage_all on public.organisations;
+create policy organisations_superuser_manage_all
+on public.organisations
+for all
+using ((auth.jwt() -> 'app_metadata' ->> 'role') = 'superuser')
+with check ((auth.jwt() -> 'app_metadata' ->> 'role') = 'superuser');
+
+drop policy if exists processes_superuser_manage_all on public.processes;
+create policy processes_superuser_manage_all
+on public.processes
+for all
+using ((auth.jwt() -> 'app_metadata' ->> 'role') = 'superuser')
+with check ((auth.jwt() -> 'app_metadata' ->> 'role') = 'superuser');
+
+-- Admins may view and update their own organisation entry.
+drop policy if exists organisations_admin_read on public.organisations;
+create policy organisations_admin_read
+on public.organisations
+for select
+using (
+  (auth.jwt() -> 'app_metadata' ->> 'role') in ('admin', 'user')
+  and id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+);
+
+drop policy if exists organisations_admin_update on public.organisations;
+create policy organisations_admin_update
+on public.organisations
+for update
+using (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin'
+  and id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+)
+with check (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin'
+  and id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+);
+
+-- Only superusers can create or delete organisations.
+drop policy if exists organisations_superuser_create on public.organisations;
+create policy organisations_superuser_create
+on public.organisations
+for insert
+with check ((auth.jwt() -> 'app_metadata' ->> 'role') = 'superuser');
+
+drop policy if exists organisations_superuser_delete on public.organisations;
+create policy organisations_superuser_delete
+on public.organisations
+for delete
+using ((auth.jwt() -> 'app_metadata' ->> 'role') = 'superuser');
+
+-- Admins can fully manage processes tied to their organisation.
+drop policy if exists processes_admin_manage_org on public.processes;
+create policy processes_admin_manage_org
+on public.processes
+for all
+using (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin'
+  and org_id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+)
+with check (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'admin'
+  and org_id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+);
+
+-- Users can read/write (but not delete) processes in their own organisation only.
+drop policy if exists processes_user_select_own_org on public.processes;
+create policy processes_user_select_own_org
+on public.processes
+for select
+using (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'user'
+  and org_id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+);
+
+drop policy if exists processes_user_insert_own_org on public.processes;
+create policy processes_user_insert_own_org
+on public.processes
+for insert
+with check (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'user'
+  and org_id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+);
+
+drop policy if exists processes_user_update_own_org on public.processes;
+create policy processes_user_update_own_org
+on public.processes
+for update
+using (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'user'
+  and org_id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+)
+with check (
+  (auth.jwt() -> 'app_metadata' ->> 'role') = 'user'
+  and org_id = ((auth.jwt() -> 'app_metadata' ->> 'org_id'))::uuid
+);
+


### PR DESCRIPTION
## Summary
- make the Supabase RBAC migration idempotent and split user-facing policies to block deletes
- add environment-variable validation to the Supabase TypeScript helpers
- document how to link the Supabase CLI before running migrations and clarify user capabilities

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fb7a32ec832491a97d64d52379d1