### PR TITLE
Enable Supabase Google login redirect

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import { Suspense, useEffect, useMemo, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+
+type SupabaseUser = {
+  id: string
+  email?: string | null
+}
+
+function parseHashParams(hash: string) {
+  const params = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash)
+  const result: Record<string, string> = {}
+
+  for (const [key, value] of params.entries()) {
+    result[key] = value
+  }
+
+  return result
+}
+
+function AuthCallbackContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [error, setError] = useState<string | null>(null)
+
+  const redirectTo = useMemo(() => {
+    const target = searchParams.get("redirect")
+
+    if (!target || !target.startsWith("/")) {
+      return "/"
+    }
+
+    return target
+  }, [searchParams])
+
+  useEffect(() => {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      setError("Supabase environment variables are not configured.")
+      return
+    }
+
+    const hashParams = parseHashParams(window.location.hash)
+    const queryState = searchParams.get("state")
+    const providerState = hashParams.state ?? queryState ?? ""
+    let storedState = ""
+
+    try {
+      storedState = sessionStorage.getItem("supabase.oauth.state") ?? ""
+    } catch {
+      storedState = ""
+    }
+
+    if (storedState && providerState && storedState !== providerState) {
+      setError("State mismatch detected. Please try logging in again.")
+      try {
+        sessionStorage.removeItem("supabase.oauth.state")
+      } catch {
+        // ignore storage access issues
+      }
+      return
+    }
+
+    try {
+      sessionStorage.removeItem("supabase.oauth.state")
+    } catch {
+      // ignore storage access issues
+    }
+
+    if (hashParams.error) {
+      setError(hashParams.error_description ?? "Unable to sign in with Google.")
+      return
+    }
+
+    const accessToken = hashParams.access_token
+    const refreshToken = hashParams.refresh_token
+
+    if (!accessToken) {
+      setError("Missing access token. Please try logging in again.")
+      return
+    }
+
+    let isMounted = true
+
+    async function establishSession() {
+      try {
+        const userResponse = await fetch(
+          `${supabaseUrl.replace(/\/$/, "")}/auth/v1/user`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              apikey: supabaseAnonKey,
+            },
+          },
+        )
+
+        if (!userResponse.ok) {
+          throw new Error("Failed to fetch Supabase user profile")
+        }
+
+        const user: SupabaseUser = await userResponse.json()
+        const email = user.email ?? `${user.id}@google-oauth`
+
+        const loginResponse = await fetch("/api/auth/login", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ email, password: "google-oauth" }),
+        })
+
+        if (!loginResponse.ok) {
+          throw new Error("Failed to establish application session")
+        }
+
+        try {
+          localStorage.setItem("supabase.access_token", accessToken)
+
+          if (refreshToken) {
+            localStorage.setItem("supabase.refresh_token", refreshToken)
+          }
+        } catch {
+          // Access to localStorage might be restricted. Ignore errors.
+        }
+
+        router.replace(redirectTo)
+        router.refresh()
+      } catch (cause) {
+        console.error("Supabase Google login failed", cause)
+
+        if (!isMounted) {
+          return
+        }
+
+        setError("Unable to complete Google sign-in. Please try again.")
+      }
+    }
+
+    establishSession()
+
+    return () => {
+      isMounted = false
+    }
+  }, [redirectTo, router, searchParams])
+
+  return (
+    <div className="flex min-h-svh items-center justify-center p-6">
+      <div className="max-w-md text-center">
+        <h1 className="text-2xl font-semibold">Signing you in…</h1>
+        <p className="text-muted-foreground mt-4 text-sm">
+          {error
+            ? error
+            : "Please wait while we finish connecting your Google account."}
+        </p>
+        {error ? (
+          <button
+            type="button"
+            className="mt-6 inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium"
+            onClick={() => router.replace("/login")}
+          >
+            Back to login
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={<AuthCallbackFallback />}> 
+      <AuthCallbackContent />
+    </Suspense>
+  )
+}
+
+function AuthCallbackFallback() {
+  return (
+    <div className="flex min-h-svh items-center justify-center p-6">
+      <div className="max-w-md text-center">
+        <h1 className="text-2xl font-semibold">Signing you in…</h1>
+        <p className="text-muted-foreground mt-4 text-sm">
+          Preparing your Google session.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react"
+
 import { GalleryVerticalEnd } from "lucide-react"
 
 import { LoginForm } from "@/components/login-form"
@@ -16,7 +18,9 @@ export default function LoginPage() {
         </div>
         <div className="flex flex-1 items-center justify-center">
           <div className="w-full max-w-xs">
-            <LoginForm />
+            <Suspense fallback={null}>
+              <LoginForm />
+            </Suspense>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update the login form to launch the Supabase Google OAuth flow with PKCE state handling
- add a dedicated `/auth/callback` client page that validates the OAuth response, fetches the Supabase profile, and seeds the existing session cookie
- wrap the login form in a suspense boundary to satisfy Next.js requirements when using `useSearchParams`

## Testing
- npm run build *(fails: existing pages such as `/` still use `useSearchParams` without a Suspense boundary)*
- npm run lint *(fails: ESLint is not installed in the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d59099f94483248bee698914ae1868