### PR TITLE
Allow auth callback to bypass middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -23,7 +23,11 @@ function resolveRedirectUrl(request: NextRequest, destination: string | null) {
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  if (pathname.startsWith("/_next") || pathname.startsWith("/api/auth")) {
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api/auth") ||
+    pathname.startsWith("/auth/callback")
+  ) {
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Summary
- ensure middleware bypasses the Supabase auth callback route so the session handoff can complete

## Testing
- pnpm lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d5955366f083248c6401f076b13e44