### PR TITLE
Guard MutationObserver observe call

### DIFF
--- a/components/disable-next-devtools.tsx
+++ b/components/disable-next-devtools.tsx
@@ -60,15 +60,37 @@ export default function DisableNextDevTools() {
       removeDevToolsElements()
     })
 
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-    })
+    const registerObserver = () => {
+      const body = document.body
+      if (!body) {
+        return false
+      }
+
+      observer.observe(body, {
+        childList: true,
+        subtree: true,
+      })
+
+      return true
+    }
+
+    let registrationIntervalId: number | undefined
+    if (!registerObserver()) {
+      registrationIntervalId = window.setInterval(() => {
+        if (registerObserver() && registrationIntervalId !== undefined) {
+          window.clearInterval(registrationIntervalId)
+          registrationIntervalId = undefined
+        }
+      }, 50)
+    }
 
     return () => {
       observer.disconnect()
       window.clearInterval(intervalId)
       window.clearTimeout(timeoutId)
+      if (registrationIntervalId !== undefined) {
+        window.clearInterval(registrationIntervalId)
+      }
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- guard the MutationObserver registration so the dev tools watcher only attaches once `document.body` exists
- clear the fallback registration interval during teardown to keep cleanup logic intact

## Testing
- pnpm dev --hostname 0.0.0.0 --port 3000 (manually verified in browser that no MutationObserver.observe error appears)


------
https://chatgpt.com/codex/tasks/task_e_68d5960283408324864d16b39907081b