### PR TITLE
Fix Supabase Google OAuth callback exchange

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -40,9 +40,9 @@ function AuthCallbackContent() {
           throw new Error("Missing authorization code. Please try logging in again.")
         }
 
-        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(
+        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession({
           authCode,
-        )
+        })
 
         if (exchangeError) {
           throw exchangeError


### PR DESCRIPTION
## Summary
- update the auth callback to call `exchangeCodeForSession` with the expected options object so Supabase receives the stored PKCE verifier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b44c0da48324a08bdba723acf7ba