### PR TITLE
Fix Google OAuth redirect to overview and persist auth cookie

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,36 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs"
+
+import { AUTH_COOKIE_NAME } from "@/lib/auth"
+
+export async function POST() {
+  const cookieStore = cookies()
+  const supabase = createRouteHandlerClient({ cookies: () => cookieStore })
+
+  const {
+    data: { session },
+    error,
+  } = await supabase.auth.getSession()
+
+  if (error || !session) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 },
+    )
+  }
+
+  const response = NextResponse.json({ success: true })
+
+  response.cookies.set({
+    name: AUTH_COOKIE_NAME,
+    value: "authenticated",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 60 * 24,
+    path: "/",
+  })
+
+  return response
+}

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -29,7 +29,22 @@ export default function AuthCallbackPage() {
 
       console.log("✅ Session established:", data.session)
 
-      const redirect = searchParams.get("redirect") ?? "/"
+      try {
+        const response = await fetch("/api/auth/session", {
+          method: "POST",
+          cache: "no-store",
+        })
+
+        if (!response.ok) {
+          throw new Error(`Unexpected response: ${response.status}`)
+        }
+      } catch (persistError) {
+        console.error("❌ Auth callback error: unable to persist session cookie", persistError)
+        router.replace("/login")
+        return
+      }
+
+      const redirect = searchParams.get("redirect") ?? "/overview"
       router.replace(redirect)
       router.refresh()
     }

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -14,7 +14,7 @@ function getSafeRedirect(searchParams: ReadonlyURLSearchParams) {
     return target
   }
 
-  return "/"
+  return "/overview"
 }
 
 export default function LoginForm() {
@@ -31,7 +31,8 @@ export default function LoginForm() {
 
     try {
       const origin = window.location.origin
-      const redirectQuery = redirectPath === "/" ? "" : `?redirect=${encodeURIComponent(redirectPath)}`
+      const redirectQuery =
+        redirectPath === "/overview" ? "" : `?redirect=${encodeURIComponent(redirectPath)}`
       const redirectTo = `${origin}/auth/callback${redirectQuery}`
 
       const { error: signInError } = await supabase.auth.signInWithOAuth({

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,7 @@ function getRedirectPath(request: NextRequest) {
 }
 
 function resolveRedirectUrl(request: NextRequest, destination: string | null) {
-  const target = destination && destination.startsWith("/") ? destination : "/"
+  const target = destination && destination.startsWith("/") ? destination : "/overview"
   return new URL(target, request.url)
 }
 


### PR DESCRIPTION
## Summary
- add a session route that persists the pb_auth_token cookie after Supabase OAuth completes
- update the auth callback to call the session route and redirect to /overview when no redirect is provided
- default login redirect helpers and middleware logic to /overview for authenticated users

## Testing
- Not run (Node.js/npm are unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6ccab91148324991eda78eeb4733d