### PR TITLE
Fix duplicate Supabase error destructuring in operations catalog

### DIFF
--- a/components/operations/operations-catalog.tsx
+++ b/components/operations/operations-catalog.tsx
@@ -272,14 +272,14 @@ export default function OpsCatalog({ query }: OpsCatalogProps) {
       : baseId
     const defaultSubcategoryId = `${uniqueId}-general`
 
-    const { data: insertedCategory, error } = await supabase
+    const { data: insertedCategory, error: insertCategoryError } = await supabase
       .from("operations_categories")
       .insert({ title: trimmed })
       .select("id")
       .single()
 
-    if (error) {
-      console.error("Failed to persist category", error)
+    if (insertCategoryError) {
+      console.error("Failed to persist category", insertCategoryError)
       return
     }
 
@@ -291,12 +291,12 @@ export default function OpsCatalog({ query }: OpsCatalogProps) {
       supabaseId: insertedCategory?.id,
     }
 
-    const { error } = await supabase
+    const { error: upsertCategoryError } = await supabase
       .from("operations_categories")
       .upsert({ id: uniqueId, title: trimmed })
 
-    if (error) {
-      console.error("Failed to persist category", error)
+    if (upsertCategoryError) {
+      console.error("Failed to persist category", upsertCategoryError)
       return
     }
 


### PR DESCRIPTION
## Summary
- rename Supabase error destructuring variables to avoid redeclaration when adding operations categories

## Testing
- pnpm lint *(fails: ESLint must be installed: pnpm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d94ef94d548324aa0d066ae1ea8b77