### PR TITLE
Fix missing Select import in operations catalog

### DIFF
--- a/components/operations/operations-catalog.tsx
+++ b/components/operations/operations-catalog.tsx
@@ -30,6 +30,7 @@ import {
 } from "../ui/dropdown-menu"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../ui/dialog"
 import { Textarea } from "../ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select"
 
 import { cn } from "@/lib/utils"
 import { deadlinesAreEqual } from "@/lib/workflow-utils"


### PR DESCRIPTION
## Summary
- import the Select component suite used in the operations catalog dialog
- resolve runtime ReferenceError when rendering the category selection UI

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68d95061d2d48324ba51ccbf77289712