### PR TITLE
Add migration to populate ticket metadata columns

### DIFF
--- a/supabase/migrations/0003_backfill_ticket_columns.sql
+++ b/supabase/migrations/0003_backfill_ticket_columns.sql
@@ -1,0 +1,12 @@
+-- Adds missing ticket columns accessed by the application UI and backfills submitted_at
+-- so that ordering logic on existing data remains consistent.
+
+alter table public.tickets
+  add column if not exists submitted_at timestamptz,
+  add column if not exists sla_due_at timestamptz,
+  add column if not exists linked_process_id uuid,
+  add column if not exists requested_by text;
+
+update public.tickets
+set submitted_at = created_at
+where submitted_at is null;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -109,7 +109,60 @@ export type Database = {
         }
         Relationships: []
       }
-      tickets: GenericTable
+      tickets: {
+        Row: {
+          id: string
+          code: string | null
+          title: string | null
+          description: string | null
+          status: string | null
+          priority: string | null
+          requested_by: string | null
+          submitted_at: string | null
+          created_at: string | null
+          updated_at: string | null
+          created_by: string | null
+          updated_by: string | null
+          service_desk_id: string | null
+          sla_due_at: string | null
+          linked_process_id: string | null
+        }
+        Insert: {
+          id?: string
+          code?: string | null
+          title?: string | null
+          description?: string | null
+          status?: string | null
+          priority?: string | null
+          requested_by?: string | null
+          submitted_at?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+          created_by?: string | null
+          updated_by?: string | null
+          service_desk_id?: string | null
+          sla_due_at?: string | null
+          linked_process_id?: string | null
+        }
+        Update: {
+          id?: string
+          code?: string | null
+          title?: string | null
+          description?: string | null
+          status?: string | null
+          priority?: string | null
+          requested_by?: string | null
+          submitted_at?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+          created_by?: string | null
+          updated_by?: string | null
+          service_desk_id?: string | null
+          sla_due_at?: string | null
+          linked_process_id?: string | null
+        }
+        Relationships: []
+      }
       ticket_comments: GenericTable
       ticket_assignments: GenericTable
       users: {


### PR DESCRIPTION
## Summary
- add a migration that ensures the ticket metadata columns exist and backfills submitted_at from created_at
- regenerate the Supabase client types so the tickets table exposes the new fields

## Testing
- not run (database tooling unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc2a384b3c8324815cc29ffdc3540e