### PR TITLE
Hide React Flow attribution in process designer

### DIFF
--- a/components/workflow-builder.tsx
+++ b/components/workflow-builder.tsx
@@ -514,6 +514,7 @@ export default function WorkflowBuilder({
               onPaneClick={onPaneClick}
               nodeTypes={nodeTypes}
               edgeTypes={edgeTypes}
+              proOptions={{ hideAttribution: true }}
               fitView
               snapToGrid
               snapGrid={[15, 15]}


### PR DESCRIPTION
## Summary
- hide the React Flow watermark by enabling the hideAttribution option on the canvas

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68de831de65883249d2ee0944521cae7