### PR TITLE
Adjust operations layout widths

### DIFF
--- a/components/operations/operations-catalog.tsx
+++ b/components/operations/operations-catalog.tsx
@@ -960,11 +960,11 @@ export default function OpsCatalog({ query }: OpsCatalogProps) {
     pendingProcessViewerPrompt?.title ?? processViewerPromptTitle.trim()
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-[#e5e7eb]">
       <div
         className={cn(
-          "mx-auto grid max-w-6xl gap-6 px-4 py-6",
-          fullscreen ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-2",
+          "grid w-full gap-6 px-4 py-6",
+          fullscreen ? "grid-cols-1" : "grid-cols-1 lg:grid-cols-[1fr_2fr]",
         )}
       >
         {!fullscreen && (


### PR DESCRIPTION
## Summary
- make the operations catalog stretch the full inset width with a 1/3–2/3 column split
- apply the updated background color so the page uses the #e5e7eb tone

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de89c2c884832494e3bdb4e6e9c240