### PR TITLE
Add insights workspace with saved chats

### DIFF
--- a/app/insights/chats/[chatId]/page.tsx
+++ b/app/insights/chats/[chatId]/page.tsx
@@ -1,0 +1,145 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import {
+  ArrowLeft,
+  Bot,
+  MessageCircle,
+  MessageSquare,
+  Sparkles,
+  User,
+} from "lucide-react"
+
+import { DashboardShell } from "@/components/dashboard-shell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { insightChatThreads } from "@/lib/data/insights"
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+export default function InsightChatDetailPage({
+  params,
+}: {
+  params: { chatId: string }
+}) {
+  const chat = insightChatThreads.find((thread) => thread.id === params.chatId)
+
+  if (!chat) {
+    notFound()
+  }
+
+  return (
+    <DashboardShell
+      header={{
+        title: chat.title,
+        description: "Saved Process AI conversation based on Supabase processes and tickets data.",
+        icon: MessageSquare,
+      }}
+    >
+      <div className="space-y-6 px-4 py-6 lg:px-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Button asChild variant="ghost" className="gap-2">
+            <Link href="/insights/chats">
+              <ArrowLeft className="h-4 w-4" />
+              Back to chats
+            </Link>
+          </Button>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <Badge variant="outline" className="bg-muted/50">
+              Updated {formatDateTime(chat.updatedAt)}
+            </Badge>
+            <Badge variant="outline" className="bg-muted/50">
+              Created {formatDateTime(chat.createdAt)}
+            </Badge>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-lg font-semibold">Highlights</CardTitle>
+            <CardDescription>Key takeaways from this AI analysis.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid gap-3 sm:grid-cols-3">
+              {chat.metrics.map((metric) => (
+                <div key={metric.label} className="rounded-lg border border-muted-foreground/30 bg-muted/20 p-4">
+                  <p className="text-xs text-muted-foreground">{metric.label}</p>
+                  <p className="text-xl font-semibold">{metric.value}</p>
+                  {metric.delta ? (
+                    <p className="text-xs text-primary">{metric.delta}</p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+            <Separator />
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {chat.highlights.map((highlight) => (
+                <li key={highlight} className="flex items-start gap-2">
+                  <MessageCircle className="mt-0.5 h-3.5 w-3.5 text-primary" />
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-lg font-semibold">Conversation</CardTitle>
+            <CardDescription>
+              Stored transcript between you and Process AI. Each follow-up is available via its unique URL.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            {chat.messages.map((message) => {
+              const isAssistant = message.role === "assistant"
+              const Icon = isAssistant ? Bot : User
+
+              return (
+                <div
+                  key={message.id}
+                  className="rounded-lg border border-border bg-background/80 p-4 shadow-sm"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2 text-sm font-medium">
+                      <Icon className="h-4 w-4 text-primary" />
+                      {isAssistant ? "Process AI" : "You"}
+                    </div>
+                    <span className="text-xs text-muted-foreground">{formatDateTime(message.timestamp)}</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-muted-foreground">{message.content}</p>
+                </div>
+              )
+            })}
+          </CardContent>
+        </Card>
+
+        <Card className="bg-muted/40">
+          <CardHeader>
+            <CardTitle className="text-base font-semibold">Suggested next steps</CardTitle>
+            <CardDescription>Send these actions to owners or spin up a new automation.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {chat.followUps.map((item) => (
+              <div key={item} className="rounded-lg border border-dashed border-muted-foreground/40 bg-background/80 p-3">
+                <p className="text-sm text-muted-foreground">{item}</p>
+              </div>
+            ))}
+            <Button asChild variant="secondary" className="w-full justify-center gap-2">
+              <Link href="/insights">
+                Start a fresh insight
+                <Sparkles className="h-4 w-4" />
+              </Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </DashboardShell>
+  )
+}

--- a/app/insights/chats/page.tsx
+++ b/app/insights/chats/page.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import Link from "next/link"
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  MessageCircle,
+  MessageSquare,
+  Sparkles,
+} from "lucide-react"
+
+import { DashboardShell } from "@/components/dashboard-shell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { insightChatThreads } from "@/lib/data/insights"
+
+export default function InsightsChatsPage() {
+  return (
+    <DashboardShell
+      header={{
+        title: "Insight chats",
+        description: "Every conversation with Process AI is saved with its own shareable URL.",
+        icon: MessageSquare,
+      }}
+      action={{
+        label: "New analysis",
+        icon: Sparkles,
+        onClick: () => {
+          window.location.href = "/insights"
+        },
+      }}
+    >
+      <div className="space-y-6 px-4 py-6 lg:px-6">
+        <div className="flex items-center justify-between gap-4">
+          <div className="text-sm text-muted-foreground">
+            {insightChatThreads.length} saved chats · Each entry opens its own URL so you can revisit the exact insight.
+          </div>
+          <Button asChild variant="ghost" className="gap-2 text-sm">
+            <Link href="/insights">
+              <ArrowLeft className="h-4 w-4" />
+              Back to Insights
+            </Link>
+          </Button>
+        </div>
+
+        <div className="grid gap-4">
+          {insightChatThreads.map((chat) => (
+            <Card key={chat.id} className="transition hover:border-primary/40">
+              <CardHeader className="space-y-2">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <CardTitle className="text-lg font-semibold">{chat.title}</CardTitle>
+                    <CardDescription>{chat.summary}</CardDescription>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {chat.tags.map((tag) => (
+                      <Badge key={tag} variant="outline" className="text-xs">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-3 sm:grid-cols-3">
+                  {chat.metrics.map((metric) => (
+                    <div key={metric.label} className="rounded-lg border border-muted-foreground/30 bg-muted/30 p-3">
+                      <p className="text-xs text-muted-foreground">{metric.label}</p>
+                      <p className="text-lg font-semibold">{metric.value}</p>
+                      {metric.delta ? (
+                        <p className="text-xs text-primary">{metric.delta}</p>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Highlights</p>
+                  <ul className="space-y-1 text-sm text-muted-foreground">
+                    {chat.highlights.map((highlight) => (
+                      <li key={highlight} className="flex items-start gap-2">
+                        <MessageCircle className="mt-0.5 h-3.5 w-3.5 text-primary" />
+                        <span>{highlight}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-xs text-muted-foreground">
+                    Updated {new Intl.DateTimeFormat("en-US", { dateStyle: "medium", timeStyle: "short" }).format(new Date(chat.updatedAt))}
+                  </span>
+                  <Button asChild variant="secondary" className="gap-2">
+                    <Link href={`/insights/chats/${chat.id}`}>
+                      Open chat
+                      <ArrowUpRight className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </DashboardShell>
+  )
+}

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -1,0 +1,293 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import {
+  ArrowUpRight,
+  Bot,
+  Database,
+  MessageSquare,
+  Sparkles,
+  TrendingUp,
+} from "lucide-react"
+
+import { DashboardShell } from "@/components/dashboard-shell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { insightChatThreads } from "@/lib/data/insights"
+
+const questionGroups = [
+  {
+    title: "AI & Automation",
+    description: "Spot automation candidates inside processes and service desk flows.",
+    icon: Bot,
+    questions: [
+      "What processes could we automate with AI to cut resolution time?",
+      "Which repetitive requests could be shifted to self-service or chatbots?",
+      "Where are manual approvals slowing things down that AI could streamline?",
+    ],
+  },
+  {
+    title: "Service Desk Efficiency",
+    description: "Understand where Supabase ticket data shows bottlenecks and escalations.",
+    icon: MessageSquare,
+    questions: [
+      "What are the most frequent service desk questions, and how can we reduce them?",
+      "Which request types create the biggest backlog, and why?",
+      "Where are tickets most often escalated — and could training or better documentation fix that?",
+    ],
+  },
+  {
+    title: "Process Bottlenecks",
+    description: "Review cycle time data to uncover slow steps across operations.",
+    icon: TrendingUp,
+    questions: [
+      "What business processes consistently take longer than expected?",
+      "Which steps in a workflow add no clear value — could they be removed?",
+      "Are there tasks that always require multiple handoffs, and can we eliminate them?",
+    ],
+  },
+] as const
+
+const dataSnapshots = [
+  {
+    label: "Active processes",
+    value: "68",
+    context: "Supabase processes table · last 30 days",
+    delta: "+12% vs prior",
+  },
+  {
+    label: "Tickets this week",
+    value: "184",
+    context: "Supabase tickets table",
+    delta: "26 at risk",
+  },
+  {
+    label: "Automation candidates",
+    value: "9",
+    context: "Flagged by AI during last analysis",
+    delta: "5 high impact",
+  },
+] as const
+
+const processOpportunities = [
+  {
+    name: "Vendor onboarding",
+    issue: "Finance review adds 29h idle time across handoffs.",
+    recommendation: "Route to automation queue with SLA nudges.",
+  },
+  {
+    name: "Access provisioning",
+    issue: "Manual approvals delay tickets past 12h SLA.",
+    recommendation: "Trigger AI-generated summaries for approvers.",
+  },
+  {
+    name: "Quarterly compliance",
+    issue: "Duplicate document uploads across steps.",
+    recommendation: "Consolidate upload step and pre-validate artifacts.",
+  },
+] as const
+
+export default function InsightsPage() {
+  const [prompt, setPrompt] = useState("")
+
+  const handleSelectQuestion = (question: string) => {
+    setPrompt(question)
+  }
+
+  const latestChat = insightChatThreads[0]
+
+  return (
+    <DashboardShell
+      header={{
+        title: "Insights",
+        description:
+          "Ask Process AI to analyze Supabase processes and tickets, surface bottlenecks, and recommend automations.",
+        icon: Sparkles,
+      }}
+    >
+      <div className="space-y-6 px-4 py-6 lg:px-6">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr),minmax(0,1fr)]">
+          <Card className="border-primary/20 bg-background/70 shadow-sm">
+            <CardHeader className="space-y-4">
+              <div className="flex flex-wrap items-center gap-3">
+                <Badge variant="secondary" className="rounded-full px-3 py-1 text-xs font-medium">
+                  Connected to Supabase
+                </Badge>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Database className="h-4 w-4" />
+                  processes · tickets
+                </div>
+              </div>
+              <div>
+                <CardTitle className="text-2xl font-semibold">Ask Process AI anything</CardTitle>
+                <CardDescription>
+                  Generate insights from your operational data without writing SQL. Pick a sample question or describe
+                  what you need and the assistant will explore both the processes and tickets tables.
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <Textarea
+                aria-label="Ask Process AI"
+                placeholder="e.g. Compare onboarding cycle time across squads and highlight the slowest approvals"
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                rows={5}
+              />
+              <div className="flex flex-wrap items-center gap-3">
+                <Button className="gap-2" size="lg">
+                  <Sparkles className="h-4 w-4" />
+                  Analyze data
+                </Button>
+                <Button asChild variant="outline" className="gap-2">
+                  <Link href="/insights/chats">
+                    <MessageSquare className="h-4 w-4" />
+                    View saved chats
+                  </Link>
+                </Button>
+              </div>
+              <Separator />
+              <div className="space-y-3">
+                <p className="text-sm font-medium text-muted-foreground">Quick starters</p>
+                <div className="flex flex-wrap gap-2">
+                  {questionGroups.flatMap((group) => group.questions.slice(0, 1)).map((question) => (
+                    <Button
+                      key={question}
+                      variant="secondary"
+                      className="h-auto rounded-full px-4 py-2 text-left text-sm"
+                      type="button"
+                      onClick={() => handleSelectQuestion(question)}
+                    >
+                      {question}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="bg-muted/40">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base font-semibold">
+                <Sparkles className="h-4 w-4 text-primary" />
+                Snapshot from Supabase
+              </CardTitle>
+              <CardDescription>
+                Live metrics pulled from the processes and tickets tables help you anchor every insight session.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid gap-4">
+                {dataSnapshots.map((snapshot) => (
+                  <div key={snapshot.label} className="rounded-lg border border-border bg-background/70 p-4">
+                    <div className="text-sm text-muted-foreground">{snapshot.label}</div>
+                    <div className="mt-1 flex items-baseline justify-between">
+                      <span className="text-2xl font-semibold">{snapshot.value}</span>
+                      <span className="text-xs font-medium text-primary">{snapshot.delta}</span>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{snapshot.context}</p>
+                  </div>
+                ))}
+              </div>
+              {latestChat ? (
+                <div className="rounded-lg border border-dashed border-primary/40 bg-background/80 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">Resume last insight</p>
+                      <p className="text-xs text-muted-foreground">{latestChat.summary}</p>
+                    </div>
+                    <Button asChild variant="ghost" className="gap-1 text-xs">
+                      <Link href={`/insights/chats/${latestChat.id}`}>
+                        Open
+                        <ArrowUpRight className="h-3 w-3" />
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <section className="grid gap-6 lg:grid-cols-3">
+          {questionGroups.map((group) => (
+            <Card key={group.title} className="h-full">
+              <CardHeader className="space-y-2">
+                <div className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+                  <group.icon className="h-4 w-4" />
+                  {group.title}
+                </div>
+                <CardDescription>{group.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {group.questions.map((question) => (
+                  <Button
+                    key={question}
+                    variant="ghost"
+                    className="h-auto justify-start whitespace-normal px-3 py-2 text-left text-sm"
+                    type="button"
+                    onClick={() => handleSelectQuestion(question)}
+                  >
+                    {question}
+                  </Button>
+                ))}
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr),minmax(0,1fr)]">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base font-semibold">
+                <Database className="h-4 w-4" />
+                Process opportunities
+              </CardTitle>
+              <CardDescription>
+                AI scans Supabase process runs to surface the slowest steps and recommended automation plays.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {processOpportunities.map((opportunity) => (
+                <div key={opportunity.name} className="rounded-lg border border-border p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="font-medium">{opportunity.name}</p>
+                    <Badge variant="outline">High impact</Badge>
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">{opportunity.issue}</p>
+                  <p className="mt-2 text-sm font-medium text-primary">{opportunity.recommendation}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base font-semibold">
+                <MessageSquare className="h-4 w-4" />
+                Suggested follow-ups
+              </CardTitle>
+              <CardDescription>Convert AI insights into next steps for your team.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {latestChat?.followUps.map((item) => (
+                <div key={item} className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/40 p-3">
+                  <p className="text-sm text-muted-foreground">{item}</p>
+                </div>
+              ))}
+              <Button asChild variant="secondary" className="w-full justify-center gap-2">
+                <Link href="/insights/chats">
+                  View all chats
+                  <ArrowUpRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </DashboardShell>
+  )
+}

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -64,6 +64,17 @@ const navMain: {
   children?: { title: string; url: string }[]
 }[] = [
   {
+    title: "Insights",
+    url: "/insights",
+    icon: Sparkles,
+    children: [
+      {
+        title: "Chats",
+        url: "/insights/chats",
+      },
+    ],
+  },
+  {
     title: "Overview",
     url: "/overview",
     icon: LayoutDashboard,

--- a/lib/data/insights.ts
+++ b/lib/data/insights.ts
@@ -1,0 +1,128 @@
+export type InsightChatMessage = {
+  id: string
+  role: "user" | "assistant"
+  content: string
+  timestamp: string
+}
+
+export type InsightChatThread = {
+  id: string
+  title: string
+  summary: string
+  createdAt: string
+  updatedAt: string
+  tags: string[]
+  highlights: string[]
+  metrics: {
+    label: string
+    value: string
+    delta?: string
+    trend?: "up" | "down"
+  }[]
+  followUps: string[]
+  messages: InsightChatMessage[]
+}
+
+export const insightChatThreads: InsightChatThread[] = [
+  {
+    id: "service-desk-backlog",
+    title: "Reduce escalation loops for access tickets",
+    summary:
+      "AI reviewed the service desk \"tickets\" table and flagged slow approvals for access provisioning requests.",
+    createdAt: "2024-06-11T14:05:00.000Z",
+    updatedAt: "2024-06-14T09:45:00.000Z",
+    tags: ["Service desk", "Tickets", "Automation"],
+    highlights: [
+      "18.4 hour average resolution time for access tickets vs 12 hour SLA.",
+      "Manual VP approval adds a median 6.7 hour delay with three handoffs.",
+      "34% of escalations cite missing documentation in the request intake form.",
+    ],
+    metrics: [
+      { label: "Tickets analyzed", value: "148", delta: "+12% MoM", trend: "up" },
+      { label: "At-risk tickets", value: "17", delta: "-3 vs last week", trend: "down" },
+      { label: "Escalation rate", value: "26%", delta: "+4 pts", trend: "up" },
+    ],
+    followUps: [
+      "Draft a playbook to auto-notify approvers when SLA risk exceeds 8 hours.",
+      "Design a required fields checklist in the request form to reduce missing details.",
+      "Simulate impact of routing approvals to the automation queue after hours.",
+    ],
+    messages: [
+      {
+        id: "1",
+        role: "user",
+        content:
+          "Analyze our Supabase tickets table and show me where service desk escalations are slowing us down.",
+        timestamp: "2024-06-14T09:45:00.000Z",
+      },
+      {
+        id: "2",
+        role: "assistant",
+        content:
+          "I reviewed 148 tickets from the last 30 days. Access provisioning requests are the biggest drag with an 18.4 hour average turnaround. Most delays occur while waiting on VP approval, which requires three handoffs and happens outside working hours 41% of the time.",
+        timestamp: "2024-06-14T09:45:15.000Z",
+      },
+      {
+        id: "3",
+        role: "assistant",
+        content:
+          "Escalations spike when requesters omit system IDs. Adding conditional required fields and a self-service knowledge article would prevent roughly 34% of escalations.",
+        timestamp: "2024-06-14T09:45:45.000Z",
+      },
+      {
+        id: "4",
+        role: "assistant",
+        content:
+          "Would you like me to draft an automation that reminds approvers after four hours or send this insight to the service desk queue?",
+        timestamp: "2024-06-14T09:46:00.000Z",
+      },
+    ],
+  },
+  {
+    id: "process-cycle-time",
+    title: "Cycle time audit for onboarding processes",
+    summary:
+      "Combined analysis of \"processes\" and \"tickets\" Supabase tables shows onboarding waiting on finance reviews.",
+    createdAt: "2024-06-09T16:20:00.000Z",
+    updatedAt: "2024-06-13T11:10:00.000Z",
+    tags: ["Processes", "Bottlenecks", "Finance"],
+    highlights: [
+      "Vendor onboarding workflow averages 5.2 days, exceeding target by 2.1 days.",
+      "Finance review queue has the longest idle time at 29 hours median.",
+      "47% of tasks require duplicate document uploads between teams.",
+    ],
+    metrics: [
+      { label: "Processes analyzed", value: "42", delta: "Last 90 days" },
+      { label: "Steps with delays", value: "7", delta: "+2 vs previous run", trend: "up" },
+      { label: "Automation candidates", value: "5", delta: "High impact", trend: "up" },
+    ],
+    followUps: [
+      "Propose an automated finance review queue with SLA alerts.",
+      "Consolidate duplicate document requests into a single shared step.",
+      "Share the cycle time heatmap with process owners.",
+    ],
+    messages: [
+      {
+        id: "1",
+        role: "user",
+        content:
+          "Where are the slowest steps across our Supabase processes table? Highlight anything that impacts onboarding.",
+        timestamp: "2024-06-13T11:10:00.000Z",
+      },
+      {
+        id: "2",
+        role: "assistant",
+        content:
+          "Onboarding workflows exceeded their SLA in 62% of runs. The finance review stage is the largest contributor with a 29 hour median wait, mostly when compliance exceptions are raised.",
+        timestamp: "2024-06-13T11:10:20.000Z",
+      },
+      {
+        id: "3",
+        role: "assistant",
+        content:
+          "Automating document validation before handoff would eliminate about 5 duplicate uploads per run.",
+        timestamp: "2024-06-13T11:10:40.000Z",
+      },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary
- add an Insights landing page that lets operators prompt Process AI, see Supabase snapshots, and launch suggested questions
- create a Chats subsection to list saved conversations and expose each chat transcript at its own URL
- seed reusable insight chat data and update the sidebar navigation so Insights appears above Overview with a Chats child link

## Testing
- pnpm lint *(fails: ESLint must be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e13d9ad93c8324b36e2b298cc59205