### PR TITLE
Fix operations catalog component export

### DIFF
--- a/components/operations/index.ts
+++ b/components/operations/index.ts
@@ -1,1 +1,1 @@
-export { default as OperationsCatalog } from "./operations-catalog"
+export { OperationsCatalog } from "./operations-catalog"

--- a/components/operations/operations-catalog.tsx
+++ b/components/operations/operations-catalog.tsx
@@ -60,7 +60,7 @@ import type {
 import { buildSopContent, filterData, slugify } from "./utils"
 import { ProcessEditor, extractPlainText } from "../process-editor"
 
-export default function OpsCatalog({ query }: OpsCatalogProps) {
+export function OperationsCatalog({ query }: OpsCatalogProps) {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [selectedSOP, setSelectedSOP] = useState<Sop | null>(null)
   const [data, setData] = useState<Category[]>([])
@@ -1660,3 +1660,5 @@ export default function OpsCatalog({ query }: OpsCatalogProps) {
     </div>
   )
 }
+
+export default OperationsCatalog


### PR DESCRIPTION
## Summary
- rename the OpsCatalog component to OperationsCatalog so the export name matches the file
- re-export the named OperationsCatalog component from the operations barrel for consistency

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e2718b07a48324881610bf603093c3